### PR TITLE
Integrate scale-info for type generation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,9 +104,16 @@ jobs:
           command:                 check
           toolchain:               stable
           args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12
-      - name: Checking v13
-        uses: actions-rs/cargo@master
+      - name:                      Checking v13
+        uses:                      actions-rs/cargo@master
         with:
-          command: check
-          toolchain: stable
-          args: --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v13
+          command:                 check
+          toolchain:               stable
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v13
+      - name:                      Checking all versions
+        uses:                      actions-rs/cargo@master
+        with:
+          command:                 check
+          toolchain:               stable
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12,v13
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           command:                 check
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --target wasm32-unknown-unknown --no-default-features 
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --target wasm32-unknown-unknown --no-default-features
 
   check-features:
     name:                          Check Features
@@ -104,3 +104,9 @@ jobs:
           command:                 check
           toolchain:               stable
           args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12
+      - name: Checking v13
+        uses: actions-rs/cargo@master
+        with:
+          command: check
+          toolchain: stable
+          args: --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v13

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -22,5 +22,6 @@ default = ["std", "v12"]
 v12 = []
 std = [
 	"codec/std",
+	"scale-info/std",
 	"serde",
 ]

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -14,12 +14,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
-scale-info = { path = "../../scale-info", package = "scale-info", default-features = false, features = ["derive"] }
+scale-info = { path = "../../scale-info", package = "scale-info", default-features = false, optional = true, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]
 default = ["std", "v12"]
 v12 = []
+v13 = ["scale-info"]
 std = [
 	"codec/std",
 	"scale-info/std",

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
+scale-info = { path = "../../scale-info", package = "scale-info", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -14,7 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
-scale-info = { path = "../../scale-info", package = "scale-info", default-features = false, optional = true, features = ["derive"] }
+cfg-if = "1.0.0"
+scale-info = { git = "https://github.com/paritytech/scale-info", default-features = false, optional = true, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -26,7 +26,7 @@ use codec::Encode;
 use scale_info::prelude::fmt::Debug;
 
 use scale_info::{
-	form::{CompactForm, Form, MetaForm},
+	form::{CompactForm, Form, FormString, MetaForm},
 	meta_type, IntoCompact, Registry, RegistryReadOnly, TypeInfo,
 };
 
@@ -40,7 +40,7 @@ pub type RuntimeMetadataLastVersion<T> = RuntimeMetadataV12<T>;
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct RuntimeMetadataPrefixed<S = &'static str>
 where
-	S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+	S: FormString,
 {
 	pub prefix: u32,
 	pub types: RegistryReadOnly<S>,

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -257,9 +257,9 @@ impl IntoCompact for EventMetadata {
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct TypeSpec<T: Form = MetaForm> {
 	/// The actual type.
-	ty: T::Type,
+	pub ty: T::Type,
 	/// The compile-time known displayed representation of the type.
-	name: T::String,
+	pub name: T::String,
 }
 
 impl IntoCompact for TypeSpec {

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -23,16 +23,11 @@
 use codec::Decode;
 use codec::Encode;
 
+use scale_info::prelude::fmt::Debug;
+
 use scale_info::{
-	form::{
-		CompactForm,
-		Form,
-		MetaForm,
-	},
-	meta_type,
-	IntoCompact,
-	Registry,
-	TypeInfo,
+	form::{CompactForm, Form, MetaForm},
+	meta_type, IntoCompact, Registry, RegistryReadOnly, TypeInfo,
 };
 
 /// Current prefix of metadata
@@ -44,8 +39,8 @@ pub type RuntimeMetadataLastVersion<T> = RuntimeMetadataV12<T>;
 #[derive(Eq, Encode, PartialEq, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct RuntimeMetadataPrefixed<S = &'static str>
-	where
-		S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
+where
+	S: PartialEq + Eq + PartialOrd + Ord + Clone + Debug,
 {
 	pub prefix: u32,
 	pub types: RegistryReadOnly<S>,
@@ -287,8 +282,8 @@ impl IntoCompact for TypeSpec {
 impl TypeSpec {
 	/// Creates a new type specification without a display name.
 	pub fn new<T>(name: &'static str) -> Self
-		where
-			T: TypeInfo + 'static,
+	where
+		T: TypeInfo + 'static,
 	{
 		Self {
 			ty: meta_type::<T>(),

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -36,7 +36,7 @@ pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 pub type RuntimeMetadataLastVersion<T> = RuntimeMetadataV12<T>;
 
 /// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq, RuntimeDebug)]
+#[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct RuntimeMetadataPrefixed<S = &'static str>
 where
@@ -52,23 +52,17 @@ impl From<RuntimeMetadataLastVersion<MetaForm>> for RuntimeMetadataPrefixed {
 		let mut registry = Registry::new();
 		let metadata = metadata.into_compact(&mut registry);
 		RuntimeMetadataPrefixed {
-			prefix: super::META_RESERVED,
+			prefix: META_RESERVED,
 			types: registry.into(),
 			metadata: RuntimeMetadata::V12(metadata),
 		}
 	}
 }
 
-impl From<RuntimeMetadataPrefixed> for sp_core::OpaqueMetadata {
-	fn from(metadata: RuntimeMetadataPrefixed) -> Self {
-		sp_core::OpaqueMetadata::new(metadata.encode())
-	}
-}
-
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
-#[derive(Eq, Encode, PartialEq, RuntimeDebug)]
+#[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub enum RuntimeMetadata<T: Form = MetaForm> {
 	/// Version 12 for runtime metadata.
@@ -76,7 +70,7 @@ pub enum RuntimeMetadata<T: Form = MetaForm> {
 }
 
 /// The metadata of a runtime.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct RuntimeMetadataV12<T: Form = MetaForm> {
 	/// Metadata of all the modules.
@@ -97,7 +91,7 @@ impl IntoCompact for RuntimeMetadataV12 {
 }
 
 /// Metadata of the extrinsic used by the runtime.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// Extrinsic version.
@@ -118,7 +112,7 @@ impl IntoCompact for ExtrinsicMetadata {
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct ModuleMetadata<T: Form = MetaForm> {
 	pub name: T::String,
@@ -142,7 +136,7 @@ impl IntoCompact for ModuleMetadata {
 }
 
 /// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct FunctionMetadata<T: Form = MetaForm> {
 	pub name: T::String,
@@ -163,7 +157,7 @@ impl IntoCompact for FunctionMetadata {
 }
 
 /// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
 	pub name: T::String,
@@ -184,7 +178,7 @@ impl IntoCompact for FunctionArgumentMetadata {
 }
 
 /// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct OuterEventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
@@ -203,7 +197,7 @@ impl IntoCompact for OuterEventMetadata {
 }
 
 /// Metadata about a module event.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct ModuleEventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
@@ -222,7 +216,7 @@ impl IntoCompact for ModuleEventMetadata {
 }
 
 /// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct EventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
@@ -259,7 +253,7 @@ impl IntoCompact for EventMetadata {
 /// `pred`'s display name is `Predicate` and the display name of
 /// the return type is simply `bool`. Note that `Predicate` could
 /// simply be a type alias to `fn(i32, i32) -> Ordering`.
-#[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct TypeSpec<T: Form = MetaForm> {
 	/// The actual type.

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -31,15 +31,11 @@ cfg_if::cfg_if! {
 
 use codec::{Encode, Output};
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "v12")] {
-		mod v12;
-		pub use v12::*;
-	} else if #[cfg(feature = "v13")] {
-		mod v13;
-		pub use v13::*;
-	}
-}
+#[cfg(feature = "v12")]
+pub mod v12;
+
+#[cfg(feature = "v13")]
+pub mod v13;
 
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
@@ -73,13 +69,13 @@ pub enum RuntimeMetadata {
 	V11(RuntimeMetadataDeprecated),
 	/// Version 12 for runtime metadata
 	#[cfg(feature = "v12")]
-	V12(RuntimeMetadataV12),
+	V12(v12::RuntimeMetadataV12),
 	/// Version 12 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v12"))]
 	V12(OpaqueMetadata),
 	/// Version 13 for runtime metadata.
 	#[cfg(feature = "v13")]
-	V13(RuntimeMetadataV13),
+	V13(v13::RuntimeMetadataV13),
 	/// Version 13 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v13"))]
 	V13(OpaqueMetadata),

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -20,445 +20,260 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-use codec::{Decode, Error, Input};
-use codec::{Encode, Output};
-#[cfg(feature = "std")]
-use serde::Serialize;
+use codec::Decode;
+use codec::Encode;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
-#[cfg(feature = "std")]
-type StringBuf = String;
+use scale_info::{
+	form::{
+		CompactForm,
+		Form,
+		MetaForm,
+	},
+	meta_type,
+	IntoCompact,
+	Registry,
+	TypeInfo,
+};
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
-/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
-/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
-#[cfg(not(feature = "std"))]
-type StringBuf = &'static str;
-
-/// A type that decodes to a different type than it encodes.
-/// The user needs to make sure that both types use the same encoding.
-///
-/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
-#[derive(Clone)]
-pub enum DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: 'static,
-{
-	Encode(B),
-	Decoded(O),
-}
-
-impl<B, O> Encode for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		match self {
-			DecodeDifferent::Encode(b) => b.encode_to(dest),
-			DecodeDifferent::Decoded(o) => o.encode_to(dest),
-		}
-	}
-}
-
-impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-}
-
-#[cfg(feature = "std")]
-impl<B, O> Decode for DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: Decode + 'static,
-{
-	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
-	}
-}
-
-impl<B, O> PartialEq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.encode() == other.encode()
-	}
-}
-
-impl<B, O> Eq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-}
-
-impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
-where
-	B: core::fmt::Debug + Eq + 'static,
-	O: core::fmt::Debug + Eq + 'static,
-{
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		match self {
-			DecodeDifferent::Encode(b) => b.fmt(f),
-			DecodeDifferent::Decoded(o) => o.fmt(f),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl<B, O> serde::Serialize for DecodeDifferent<B, O>
-where
-	B: serde::Serialize + 'static,
-	O: serde::Serialize + 'static,
-{
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			DecodeDifferent::Encode(b) => b.serialize(serializer),
-			DecodeDifferent::Decoded(o) => o.serialize(serializer),
-		}
-	}
-}
-
-pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
-
-type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
-
-/// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct FunctionMetadata {
-	pub name: DecodeDifferentStr,
-	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct FunctionArgumentMetadata {
-	pub name: DecodeDifferentStr,
-	pub ty: DecodeDifferentStr,
-}
-
-/// Newtype wrapper for support encoding functions (actual the result of the function).
-#[derive(Clone, Eq)]
-pub struct FnEncode<E>(pub fn() -> E)
-where
-	E: Encode + 'static;
-
-impl<E: Encode> Encode for FnEncode<E> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		self.0().encode_to(dest);
-	}
-}
-
-impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
-
-impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
-	fn eq(&self, other: &Self) -> bool {
-		self.0().eq(&other.0())
-	}
-}
-
-impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.0().fmt(f)
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		self.0().serialize(serializer)
-	}
-}
-
-/// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct OuterEventMetadata {
-	pub name: DecodeDifferentStr,
-	pub events: DecodeDifferentArray<
-		(&'static str, FnEncode<&'static [EventMetadata]>),
-		(StringBuf, Vec<EventMetadata>),
-	>,
-}
-
-/// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct EventMetadata {
-	pub name: DecodeDifferentStr,
-	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct StorageEntryMetadata {
-	pub name: DecodeDifferentStr,
-	pub modifier: StorageEntryModifier,
-	pub ty: StorageEntryType,
-	pub default: ByteGetter,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ModuleConstantMetadata {
-	pub name: DecodeDifferentStr,
-	pub ty: DecodeDifferentStr,
-	pub value: ByteGetter,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ErrorMetadata {
-	pub name: DecodeDifferentStr,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about errors in a module.
-pub trait ModuleErrorMetadata {
-	fn metadata() -> &'static [ErrorMetadata];
-}
-
-impl ModuleErrorMetadata for &'static str {
-	fn metadata() -> &'static [ErrorMetadata] {
-		&[]
-	}
-}
-
-/// A technical trait to store lazy initiated vec value as static dyn pointer.
-pub trait DefaultByte: Send + Sync {
-	fn default_byte(&self) -> Vec<u8>;
-}
-
-/// Wrapper over dyn pointer for accessing a cached once byte value.
-#[derive(Clone)]
-pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
-
-/// Decode different for static lazy initiated byte value.
-pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
-
-impl Encode for DefaultByteGetter {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		self.0.default_byte().encode_to(dest)
-	}
-}
-
-impl codec::EncodeLike for DefaultByteGetter {}
-
-impl PartialEq<DefaultByteGetter> for DefaultByteGetter {
-	fn eq(&self, other: &DefaultByteGetter) -> bool {
-		let left = self.0.default_byte();
-		let right = other.0.default_byte();
-		left.eq(&right)
-	}
-}
-
-impl Eq for DefaultByteGetter {}
-
-#[cfg(feature = "std")]
-impl serde::Serialize for DefaultByteGetter {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		self.0.default_byte().serialize(serializer)
-	}
-}
-
-impl core::fmt::Debug for DefaultByteGetter {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.0.default_byte().fmt(f)
-	}
-}
-
-/// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum StorageHasher {
-	Blake2_128,
-	Blake2_256,
-	Blake2_128Concat,
-	Twox128,
-	Twox256,
-	Twox64Concat,
-	Identity,
-}
-
-/// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum StorageEntryType {
-	Plain(DecodeDifferentStr),
-	Map {
-		hasher: StorageHasher,
-		key: DecodeDifferentStr,
-		value: DecodeDifferentStr,
-		// is_linked flag previously, unused now to keep backwards compat
-		unused: bool,
-	},
-	DoubleMap {
-		hasher: StorageHasher,
-		key1: DecodeDifferentStr,
-		key2: DecodeDifferentStr,
-		value: DecodeDifferentStr,
-		key2_hasher: StorageHasher,
-	},
-}
-
-/// A storage entry modifier.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum StorageEntryModifier {
-	Optional,
-	Default,
-}
-
-/// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct StorageMetadata {
-	/// The common prefix used by all storage entries.
-	pub prefix: DecodeDifferent<&'static str, StringBuf>,
-	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
-}
+pub type RuntimeMetadataLastVersion<T> = RuntimeMetadataV12<T>;
 
 /// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct RuntimeMetadataPrefixed<T: Form = MetaForm>(pub u32, pub RuntimeMetadata<T>);
 
-/// Metadata of the extrinsic used by the runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ExtrinsicMetadata {
-	/// Extrinsic version.
-	pub version: u8,
-	/// The signed extensions in the order they appear in the extrinsic.
-	pub signed_extensions: Vec<DecodeDifferentStr>,
+impl From<RuntimeMetadataLastVersion<CompactForm>> for RuntimeMetadataPrefixed<CompactForm> {
+	fn from(metadata: RuntimeMetadataLastVersion<CompactForm>) -> RuntimeMetadataPrefixed<CompactForm> {
+		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V12(metadata))
+	}
 }
 
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum RuntimeMetadata {
-	/// Unused; enum filler.
-	V0(RuntimeMetadataDeprecated),
-	/// Version 1 for runtime metadata. No longer used.
-	V1(RuntimeMetadataDeprecated),
-	/// Version 2 for runtime metadata. No longer used.
-	V2(RuntimeMetadataDeprecated),
-	/// Version 3 for runtime metadata. No longer used.
-	V3(RuntimeMetadataDeprecated),
-	/// Version 4 for runtime metadata. No longer used.
-	V4(RuntimeMetadataDeprecated),
-	/// Version 5 for runtime metadata. No longer used.
-	V5(RuntimeMetadataDeprecated),
-	/// Version 6 for runtime metadata. No longer used.
-	V6(RuntimeMetadataDeprecated),
-	/// Version 7 for runtime metadata. No longer used.
-	V7(RuntimeMetadataDeprecated),
-	/// Version 8 for runtime metadata. No longer used.
-	V8(RuntimeMetadataDeprecated),
-	/// Version 9 for runtime metadata. No longer used.
-	V9(RuntimeMetadataDeprecated),
-	/// Version 10 for runtime metadata. No longer used.
-	V10(RuntimeMetadataDeprecated),
-	/// Version 11 for runtime metadata. No longer used.
-	V11(RuntimeMetadataDeprecated),
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub enum RuntimeMetadata<T: Form = MetaForm> {
 	/// Version 12 for runtime metadata.
-	#[cfg(feature = "v12")]
-	V12(RuntimeMetadataV12),
-	#[cfg(not(feature = "v12"))]
-	V12(RuntimeMetadataDeprecated),
-}
-
-/// Enum that should fail.
-#[derive(Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Serialize, Debug))]
-pub enum RuntimeMetadataDeprecated {}
-
-impl Encode for RuntimeMetadataDeprecated {
-	fn encode_to<W: Output>(&self, _dest: &mut W) {}
-}
-
-impl codec::EncodeLike for RuntimeMetadataDeprecated {}
-
-#[cfg(feature = "std")]
-impl Decode for RuntimeMetadataDeprecated {
-	fn decode<I: Input>(_input: &mut I) -> Result<Self, Error> {
-		Err("Decoding is not supported".into())
-	}
+	V12(RuntimeMetadataV12<T>),
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg(feature = "v12")]
-pub struct RuntimeMetadataV12 {
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct RuntimeMetadataV12<T: Form = MetaForm> {
 	/// Metadata of all the modules.
-	pub modules: DecodeDifferentArray<ModuleMetadata>,
-	/// Metadata of the extrinsic.
-	pub extrinsic: ExtrinsicMetadata,
+	pub modules: Vec<ModuleMetadata<T>>,
+	// /// Metadata of the extrinsic.
+	// pub extrinsic: ExtrinsicMetadata<F>,
 }
 
-/// The latest version of the metadata.
-#[cfg(feature = "v12")]
-pub type RuntimeMetadataLastVersion = RuntimeMetadataV12;
+impl IntoCompact for RuntimeMetadataV12 {
+	type Output = RuntimeMetadataV12<CompactForm>;
 
-#[cfg(feature = "v12")]
-impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
-	fn into(self) -> RuntimeMetadataPrefixed {
-		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V12(self))
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		RuntimeMetadataV12 {
+			modules: registry.map_into_compact(self.modules),
+			// extrinsic: self.extrinsic.into_compact(registry),
+		}
+	}
+}
+
+/// Metadata of the extrinsic used by the runtime.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct ExtrinsicMetadata<T: Form = MetaForm> {
+	/// Extrinsic version.
+	pub version: u8,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: Vec<T::Type>,
+}
+
+impl IntoCompact for ExtrinsicMetadata {
+	type Output = ExtrinsicMetadata<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		ExtrinsicMetadata {
+			version: self.version,
+			signed_extensions: registry.register_types(self.signed_extensions),
+		}
 	}
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ModuleMetadata {
-	pub name: DecodeDifferentStr,
-	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
-	pub calls: ODFnA<FunctionMetadata>,
-	pub event: ODFnA<EventMetadata>,
-	pub constants: DFnA<ModuleConstantMetadata>,
-	pub errors: DFnA<ErrorMetadata>,
-	/// Define the index of the module, this index will be used for the encoding of module event,
-	/// call and origin variants.
-	pub index: u8,
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct ModuleMetadata<T: Form = MetaForm> {
+	pub name: T::String,
+	// pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+	pub calls: Option<Vec<FunctionMetadata<T>>>,
+	pub event: Option<Vec<EventMetadata<T>>>,
+	// pub constants: DFnA<ModuleConstantMetadata>,
+	// pub errors: DFnA<ErrorMetadata>,
 }
 
-type ODFnA<T> = Option<DFnA<T>>;
-type DFnA<T> = DecodeDifferent<FnEncode<&'static [T]>, Vec<T>>;
+impl IntoCompact for ModuleMetadata {
+	type Output = ModuleMetadata<CompactForm>;
 
-impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
-	fn into(self) -> Vec<u8> {
-		self.encode()
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		ModuleMetadata {
+			name: self.name.into_compact(registry),
+			calls: self.calls.map(|calls| registry.map_into_compact(calls)),
+			event: self.event.map(|event| registry.map_into_compact(event)),
+		}
+	}
+}
+
+/// All the metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct FunctionMetadata<T: Form = MetaForm> {
+	pub name: T::String,
+	pub arguments: Vec<FunctionArgumentMetadata<T>>,
+	pub documentation: Vec<T::String>,
+}
+
+impl IntoCompact for FunctionMetadata {
+	type Output = FunctionMetadata<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		FunctionMetadata {
+			name: self.name.into_compact(registry),
+			arguments: registry.map_into_compact(self.arguments),
+			documentation: registry.map_into_compact(self.documentation),
+		}
+	}
+}
+
+/// All the metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
+	pub name: T::String,
+	pub ty: T::Type,
+	pub is_compact: bool,
+}
+
+impl IntoCompact for FunctionArgumentMetadata {
+	type Output = FunctionArgumentMetadata<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		FunctionArgumentMetadata {
+			name: self.name.into_compact(registry),
+			ty: registry.register_type(&self.ty),
+			is_compact: self.is_compact,
+		}
+	}
+}
+
+/// All the metadata about an outer event.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct OuterEventMetadata<T: Form = MetaForm> {
+	pub name: T::String,
+	pub events: Vec<ModuleEventMetadata<T>>,
+}
+
+impl IntoCompact for OuterEventMetadata {
+	type Output = OuterEventMetadata<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		OuterEventMetadata {
+			name: self.name.into_compact(registry),
+			events: registry.map_into_compact(self.events),
+		}
+	}
+}
+
+/// Metadata about a module event.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct ModuleEventMetadata<T: Form = MetaForm> {
+	pub name: T::String,
+	pub events: Vec<EventMetadata<T>>,
+}
+
+impl IntoCompact for ModuleEventMetadata {
+	type Output = ModuleEventMetadata<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		ModuleEventMetadata {
+			name: self.name.into_compact(registry),
+			events: registry.map_into_compact(self.events),
+		}
+	}
+}
+
+/// All the metadata about an event.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct EventMetadata<T: Form = MetaForm> {
+	pub name: T::String,
+	pub arguments: Vec<TypeSpec<T>>,
+	pub documentation: Vec<T::String>,
+}
+
+impl IntoCompact for EventMetadata {
+	type Output = EventMetadata<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		EventMetadata {
+			name: self.name.into_compact(registry),
+			arguments: registry.map_into_compact(self.arguments),
+			documentation: registry.map_into_compact(self.documentation),
+		}
+	}
+}
+
+/// A type specification.
+///
+/// This contains the actual type as well as an optional compile-time
+/// known displayed representation of the type. This is useful for cases
+/// where the type is used through a type alias in order to provide
+/// information about the alias name.
+///
+/// # Examples
+///
+/// Consider the following Rust function:
+/// ```no_compile
+/// fn is_sorted(input: &[i32], pred: Predicate) -> bool;
+/// ```
+/// In this above example `input` would have no displayable name,
+/// `pred`'s display name is `Predicate` and the display name of
+/// the return type is simply `bool`. Note that `Predicate` could
+/// simply be a type alias to `fn(i32, i32) -> Ordering`.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct TypeSpec<T: Form = MetaForm> {
+	/// The actual type.
+	ty: T::Type,
+	/// The compile-time known displayed representation of the type.
+	name: T::String,
+}
+
+impl IntoCompact for TypeSpec {
+	type Output = TypeSpec<CompactForm>;
+
+	fn into_compact(self, registry: &mut Registry) -> Self::Output {
+		TypeSpec {
+			ty: registry.register_type(&self.ty),
+			name: self.name.into_compact(registry),
+		}
+	}
+}
+
+impl TypeSpec {
+	/// Creates a new type specification without a display name.
+	pub fn new<T>(name: &'static str) -> Self
+		where
+			T: TypeInfo + 'static,
+	{
+		Self {
+			ty: meta_type::<T>(),
+			name,
+		}
 	}
 }

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -23,6 +23,9 @@ cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
 		use serde::Serialize;
+	} else {
+		extern crate alloc;
+		use alloc::vec::Vec;
 	}
 }
 
@@ -32,81 +35,60 @@ cfg_if::cfg_if! {
 	if #[cfg(feature = "v12")] {
 		mod v12;
 		pub use v12::*;
-
-		/// The metadata of a runtime.
-		/// The version ID encoded/decoded through
-		/// the enum nature of `RuntimeMetadata`.
-		#[derive(Eq, Encode, PartialEq)]
-		#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-		pub enum RuntimeMetadata {
-			/// Unused; enum filler.
-			V0(RuntimeMetadataDeprecated),
-			/// Version 1 for runtime metadata. No longer used.
-			V1(RuntimeMetadataDeprecated),
-			/// Version 2 for runtime metadata. No longer used.
-			V2(RuntimeMetadataDeprecated),
-			/// Version 3 for runtime metadata. No longer used.
-			V3(RuntimeMetadataDeprecated),
-			/// Version 4 for runtime metadata. No longer used.
-			V4(RuntimeMetadataDeprecated),
-			/// Version 5 for runtime metadata. No longer used.
-			V5(RuntimeMetadataDeprecated),
-			/// Version 6 for runtime metadata. No longer used.
-			V6(RuntimeMetadataDeprecated),
-			/// Version 7 for runtime metadata. No longer used.
-			V7(RuntimeMetadataDeprecated),
-			/// Version 8 for runtime metadata. No longer used.
-			V8(RuntimeMetadataDeprecated),
-			/// Version 9 for runtime metadata. No longer used.
-			V9(RuntimeMetadataDeprecated),
-			/// Version 10 for runtime metadata. No longer used.
-			V10(RuntimeMetadataDeprecated),
-			/// Version 11 for runtime metadata. No longer used.
-			V11(RuntimeMetadataDeprecated),
-			/// Version 12 for runtime metadata.
-			V12(RuntimeMetadataV12),
-		}
 	} else if #[cfg(feature = "v13")] {
 		mod v13;
 		pub use v13::*;
-
-		/// The metadata of a runtime.
-		/// The version ID encoded/decoded through
-		/// the enum nature of `RuntimeMetadata`.
-		#[derive(Eq, Encode, PartialEq)]
-		#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-		pub enum RuntimeMetadata {
-			/// Unused; enum filler.
-			V0(RuntimeMetadataDeprecated),
-			/// Version 1 for runtime metadata. No longer used.
-			V1(RuntimeMetadataDeprecated),
-			/// Version 2 for runtime metadata. No longer used.
-			V2(RuntimeMetadataDeprecated),
-			/// Version 3 for runtime metadata. No longer used.
-			V3(RuntimeMetadataDeprecated),
-			/// Version 4 for runtime metadata. No longer used.
-			V4(RuntimeMetadataDeprecated),
-			/// Version 5 for runtime metadata. No longer used.
-			V5(RuntimeMetadataDeprecated),
-			/// Version 6 for runtime metadata. No longer used.
-			V6(RuntimeMetadataDeprecated),
-			/// Version 7 for runtime metadata. No longer used.
-			V7(RuntimeMetadataDeprecated),
-			/// Version 8 for runtime metadata. No longer used.
-			V8(RuntimeMetadataDeprecated),
-			/// Version 9 for runtime metadata. No longer used.
-			V9(RuntimeMetadataDeprecated),
-			/// Version 10 for runtime metadata. No longer used.
-			V10(RuntimeMetadataDeprecated),
-			/// Version 11 for runtime metadata. No longer used.
-			V11(RuntimeMetadataDeprecated),
-			/// Version 12 for runtime metadata. No longer used.
-			V12(RuntimeMetadataDeprecated),
-			/// Version 13 for runtime metadata.
-			V13(RuntimeMetadataV13),
-		}
 	}
 }
+
+/// The metadata of a runtime.
+/// The version ID encoded/decoded through
+/// the enum nature of `RuntimeMetadata`.
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum RuntimeMetadata {
+	/// Unused; enum filler.
+	V0(RuntimeMetadataDeprecated),
+	/// Version 1 for runtime metadata. No longer used.
+	V1(RuntimeMetadataDeprecated),
+	/// Version 2 for runtime metadata. No longer used.
+	V2(RuntimeMetadataDeprecated),
+	/// Version 3 for runtime metadata. No longer used.
+	V3(RuntimeMetadataDeprecated),
+	/// Version 4 for runtime metadata. No longer used.
+	V4(RuntimeMetadataDeprecated),
+	/// Version 5 for runtime metadata. No longer used.
+	V5(RuntimeMetadataDeprecated),
+	/// Version 6 for runtime metadata. No longer used.
+	V6(RuntimeMetadataDeprecated),
+	/// Version 7 for runtime metadata. No longer used.
+	V7(RuntimeMetadataDeprecated),
+	/// Version 8 for runtime metadata. No longer used.
+	V8(RuntimeMetadataDeprecated),
+	/// Version 9 for runtime metadata. No longer used.
+	V9(RuntimeMetadataDeprecated),
+	/// Version 10 for runtime metadata. No longer used.
+	V10(RuntimeMetadataDeprecated),
+	/// Version 11 for runtime metadata. No longer used.
+	V11(RuntimeMetadataDeprecated),
+	/// Version 12 for runtime metadata
+	#[cfg(feature = "v12")]
+	V12(RuntimeMetadataV12),
+	/// Version 12 for runtime metadata, as raw encoded bytes.
+	#[cfg(not(feature = "v12"))]
+	V12(OpaqueMetadata),
+	/// Version 13 for runtime metadata.
+	#[cfg(feature = "v13")]
+	V13(RuntimeMetadataV13),
+	/// Version 13 for runtime metadata, as raw encoded bytes.
+	#[cfg(not(feature = "v13"))]
+	V13(OpaqueMetadata),
+}
+
+/// Stores the encoded `RuntimeMetadata` as raw bytes.
+#[derive(Encode, Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct OpaqueMetadata(pub Vec<u8>);
 
 /// Enum that should fail.
 #[derive(Eq, PartialEq)]

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -19,389 +19,93 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "v13")]
-mod v13;
+cfg_if::cfg_if! {
+	if #[cfg(feature = "std")] {
+		use codec::{Decode, Error, Input};
+		use serde::Serialize;
+	}
+}
 
-#[cfg(feature = "std")]
-use codec::{Decode, Error, Input};
 use codec::{Encode, Output};
-#[cfg(feature = "std")]
-use serde::Serialize;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+cfg_if::cfg_if! {
+	if #[cfg(feature = "v12")] {
+		mod v12;
+		pub use v12::*;
 
-#[cfg(feature = "std")]
-type StringBuf = String;
+		/// The metadata of a runtime.
+		/// The version ID encoded/decoded through
+		/// the enum nature of `RuntimeMetadata`.
+		#[derive(Eq, Encode, PartialEq)]
+		#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+		pub enum RuntimeMetadata {
+			/// Unused; enum filler.
+			V0(RuntimeMetadataDeprecated),
+			/// Version 1 for runtime metadata. No longer used.
+			V1(RuntimeMetadataDeprecated),
+			/// Version 2 for runtime metadata. No longer used.
+			V2(RuntimeMetadataDeprecated),
+			/// Version 3 for runtime metadata. No longer used.
+			V3(RuntimeMetadataDeprecated),
+			/// Version 4 for runtime metadata. No longer used.
+			V4(RuntimeMetadataDeprecated),
+			/// Version 5 for runtime metadata. No longer used.
+			V5(RuntimeMetadataDeprecated),
+			/// Version 6 for runtime metadata. No longer used.
+			V6(RuntimeMetadataDeprecated),
+			/// Version 7 for runtime metadata. No longer used.
+			V7(RuntimeMetadataDeprecated),
+			/// Version 8 for runtime metadata. No longer used.
+			V8(RuntimeMetadataDeprecated),
+			/// Version 9 for runtime metadata. No longer used.
+			V9(RuntimeMetadataDeprecated),
+			/// Version 10 for runtime metadata. No longer used.
+			V10(RuntimeMetadataDeprecated),
+			/// Version 11 for runtime metadata. No longer used.
+			V11(RuntimeMetadataDeprecated),
+			/// Version 12 for runtime metadata.
+			V12(RuntimeMetadataV12),
+		}
+	} else if #[cfg(feature = "v13")] {
+		mod v13;
+		pub use v13::*;
 
-/// Current prefix of metadata
-pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
-
-/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
-/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
-#[cfg(not(feature = "std"))]
-type StringBuf = &'static str;
-
-/// A type that decodes to a different type than it encodes.
-/// The user needs to make sure that both types use the same encoding.
-///
-/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
-#[derive(Clone)]
-pub enum DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: 'static,
-{
-	Encode(B),
-	Decoded(O),
-}
-
-impl<B, O> Encode for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		match self {
-			DecodeDifferent::Encode(b) => b.encode_to(dest),
-			DecodeDifferent::Decoded(o) => o.encode_to(dest),
+		/// The metadata of a runtime.
+		/// The version ID encoded/decoded through
+		/// the enum nature of `RuntimeMetadata`.
+		#[derive(Eq, Encode, PartialEq)]
+		#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+		pub enum RuntimeMetadata {
+			/// Unused; enum filler.
+			V0(RuntimeMetadataDeprecated),
+			/// Version 1 for runtime metadata. No longer used.
+			V1(RuntimeMetadataDeprecated),
+			/// Version 2 for runtime metadata. No longer used.
+			V2(RuntimeMetadataDeprecated),
+			/// Version 3 for runtime metadata. No longer used.
+			V3(RuntimeMetadataDeprecated),
+			/// Version 4 for runtime metadata. No longer used.
+			V4(RuntimeMetadataDeprecated),
+			/// Version 5 for runtime metadata. No longer used.
+			V5(RuntimeMetadataDeprecated),
+			/// Version 6 for runtime metadata. No longer used.
+			V6(RuntimeMetadataDeprecated),
+			/// Version 7 for runtime metadata. No longer used.
+			V7(RuntimeMetadataDeprecated),
+			/// Version 8 for runtime metadata. No longer used.
+			V8(RuntimeMetadataDeprecated),
+			/// Version 9 for runtime metadata. No longer used.
+			V9(RuntimeMetadataDeprecated),
+			/// Version 10 for runtime metadata. No longer used.
+			V10(RuntimeMetadataDeprecated),
+			/// Version 11 for runtime metadata. No longer used.
+			V11(RuntimeMetadataDeprecated),
+			/// Version 12 for runtime metadata. No longer used.
+			V12(RuntimeMetadataDeprecated),
+			/// Version 13 for runtime metadata.
+			V13(RuntimeMetadataV13),
 		}
 	}
-}
-
-impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-}
-
-#[cfg(feature = "std")]
-impl<B, O> Decode for DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: Decode + 'static,
-{
-	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
-	}
-}
-
-impl<B, O> PartialEq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.encode() == other.encode()
-	}
-}
-
-impl<B, O> Eq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-}
-
-impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
-where
-	B: core::fmt::Debug + Eq + 'static,
-	O: core::fmt::Debug + Eq + 'static,
-{
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		match self {
-			DecodeDifferent::Encode(b) => b.fmt(f),
-			DecodeDifferent::Decoded(o) => o.fmt(f),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl<B, O> serde::Serialize for DecodeDifferent<B, O>
-where
-	B: serde::Serialize + 'static,
-	O: serde::Serialize + 'static,
-{
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			DecodeDifferent::Encode(b) => b.serialize(serializer),
-			DecodeDifferent::Decoded(o) => o.serialize(serializer),
-		}
-	}
-}
-
-pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
-
-type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
-
-/// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct FunctionMetadata {
-	pub name: DecodeDifferentStr,
-	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct FunctionArgumentMetadata {
-	pub name: DecodeDifferentStr,
-	pub ty: DecodeDifferentStr,
-}
-
-/// Newtype wrapper for support encoding functions (actual the result of the function).
-#[derive(Clone, Eq)]
-pub struct FnEncode<E>(pub fn() -> E)
-where
-	E: Encode + 'static;
-
-impl<E: Encode> Encode for FnEncode<E> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		self.0().encode_to(dest);
-	}
-}
-
-impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
-
-impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
-	fn eq(&self, other: &Self) -> bool {
-		self.0().eq(&other.0())
-	}
-}
-
-impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.0().fmt(f)
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		self.0().serialize(serializer)
-	}
-}
-
-/// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct OuterEventMetadata {
-	pub name: DecodeDifferentStr,
-	pub events: DecodeDifferentArray<
-		(&'static str, FnEncode<&'static [EventMetadata]>),
-		(StringBuf, Vec<EventMetadata>),
-	>,
-}
-
-/// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct EventMetadata {
-	pub name: DecodeDifferentStr,
-	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct StorageEntryMetadata {
-	pub name: DecodeDifferentStr,
-	pub modifier: StorageEntryModifier,
-	pub ty: StorageEntryType,
-	pub default: ByteGetter,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ModuleConstantMetadata {
-	pub name: DecodeDifferentStr,
-	pub ty: DecodeDifferentStr,
-	pub value: ByteGetter,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ErrorMetadata {
-	pub name: DecodeDifferentStr,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about errors in a module.
-pub trait ModuleErrorMetadata {
-	fn metadata() -> &'static [ErrorMetadata];
-}
-
-impl ModuleErrorMetadata for &'static str {
-	fn metadata() -> &'static [ErrorMetadata] {
-		&[]
-	}
-}
-
-/// A technical trait to store lazy initiated vec value as static dyn pointer.
-pub trait DefaultByte: Send + Sync {
-	fn default_byte(&self) -> Vec<u8>;
-}
-
-/// Wrapper over dyn pointer for accessing a cached once byte value.
-#[derive(Clone)]
-pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
-
-/// Decode different for static lazy initiated byte value.
-pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
-
-impl Encode for DefaultByteGetter {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		self.0.default_byte().encode_to(dest)
-	}
-}
-
-impl codec::EncodeLike for DefaultByteGetter {}
-
-impl PartialEq<DefaultByteGetter> for DefaultByteGetter {
-	fn eq(&self, other: &DefaultByteGetter) -> bool {
-		let left = self.0.default_byte();
-		let right = other.0.default_byte();
-		left.eq(&right)
-	}
-}
-
-impl Eq for DefaultByteGetter {}
-
-#[cfg(feature = "std")]
-impl serde::Serialize for DefaultByteGetter {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		self.0.default_byte().serialize(serializer)
-	}
-}
-
-impl core::fmt::Debug for DefaultByteGetter {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.0.default_byte().fmt(f)
-	}
-}
-
-/// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum StorageHasher {
-	Blake2_128,
-	Blake2_256,
-	Blake2_128Concat,
-	Twox128,
-	Twox256,
-	Twox64Concat,
-	Identity,
-}
-
-/// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum StorageEntryType {
-	Plain(DecodeDifferentStr),
-	Map {
-		hasher: StorageHasher,
-		key: DecodeDifferentStr,
-		value: DecodeDifferentStr,
-		// is_linked flag previously, unused now to keep backwards compat
-		unused: bool,
-	},
-	DoubleMap {
-		hasher: StorageHasher,
-		key1: DecodeDifferentStr,
-		key2: DecodeDifferentStr,
-		value: DecodeDifferentStr,
-		key2_hasher: StorageHasher,
-	},
-}
-
-/// A storage entry modifier.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum StorageEntryModifier {
-	Optional,
-	Default,
-}
-
-/// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct StorageMetadata {
-	/// The common prefix used by all storage entries.
-	pub prefix: DecodeDifferent<&'static str, StringBuf>,
-	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
-}
-
-/// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
-
-/// Metadata of the extrinsic used by the runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ExtrinsicMetadata {
-	/// Extrinsic version.
-	pub version: u8,
-	/// The signed extensions in the order they appear in the extrinsic.
-	pub signed_extensions: Vec<DecodeDifferentStr>,
-}
-
-/// The metadata of a runtime.
-/// The version ID encoded/decoded through
-/// the enum nature of `RuntimeMetadata`.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum RuntimeMetadata {
-	/// Unused; enum filler.
-	V0(RuntimeMetadataDeprecated),
-	/// Version 1 for runtime metadata. No longer used.
-	V1(RuntimeMetadataDeprecated),
-	/// Version 2 for runtime metadata. No longer used.
-	V2(RuntimeMetadataDeprecated),
-	/// Version 3 for runtime metadata. No longer used.
-	V3(RuntimeMetadataDeprecated),
-	/// Version 4 for runtime metadata. No longer used.
-	V4(RuntimeMetadataDeprecated),
-	/// Version 5 for runtime metadata. No longer used.
-	V5(RuntimeMetadataDeprecated),
-	/// Version 6 for runtime metadata. No longer used.
-	V6(RuntimeMetadataDeprecated),
-	/// Version 7 for runtime metadata. No longer used.
-	V7(RuntimeMetadataDeprecated),
-	/// Version 8 for runtime metadata. No longer used.
-	V8(RuntimeMetadataDeprecated),
-	/// Version 9 for runtime metadata. No longer used.
-	V9(RuntimeMetadataDeprecated),
-	/// Version 10 for runtime metadata. No longer used.
-	V10(RuntimeMetadataDeprecated),
-	/// Version 11 for runtime metadata. No longer used.
-	V11(RuntimeMetadataDeprecated),
-	/// Version 12 for runtime metadata.
-	#[cfg(feature = "v12")]
-	V12(RuntimeMetadataV12),
-	#[cfg(not(feature = "v12"))]
-	V12(RuntimeMetadataDeprecated),
-	#[cfg(feature = "v13")]
-	V13(RuntimeMetadataV13),
 }
 
 /// Enum that should fail.
@@ -419,62 +123,5 @@ impl codec::EncodeLike for RuntimeMetadataDeprecated {}
 impl Decode for RuntimeMetadataDeprecated {
 	fn decode<I: Input>(_input: &mut I) -> Result<Self, Error> {
 		Err("Decoding is not supported".into())
-	}
-}
-
-/// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg(feature = "v12")]
-pub struct RuntimeMetadataV12 {
-	/// Metadata of all the modules.
-	pub modules: DecodeDifferentArray<ModuleMetadata>,
-	/// Metadata of the extrinsic.
-	pub extrinsic: ExtrinsicMetadata,
-}
-
-/// The latest version of the metadata.
-#[cfg(feature = "v12")]
-pub type RuntimeMetadataLastVersion = RuntimeMetadataV12;
-
-#[cfg(feature = "v12")]
-impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
-	fn into(self) -> RuntimeMetadataPrefixed {
-		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V12(self))
-	}
-}
-
-/// The latest version of the metadata.
-#[cfg(feature = "v13")]
-pub type RuntimeMetadataLastVersion = v13::RuntimeMetadataV13<scale_info::form::MetaForm>;
-
-#[cfg(feature = "v13")]
-impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
-	fn into(self) -> RuntimeMetadataPrefixed {
-		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V13(self))
-	}
-}
-
-/// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct ModuleMetadata {
-	pub name: DecodeDifferentStr,
-	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
-	pub calls: ODFnA<FunctionMetadata>,
-	pub event: ODFnA<EventMetadata>,
-	pub constants: DFnA<ModuleConstantMetadata>,
-	pub errors: DFnA<ErrorMetadata>,
-	/// Define the index of the module, this index will be used for the encoding of module event,
-	/// call and origin variants.
-	pub index: u8,
-}
-
-type ODFnA<T> = Option<DFnA<T>>;
-type DFnA<T> = DecodeDifferent<FnEncode<&'static [T]>, Vec<T>>;
-
-impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
-	fn into(self) -> Vec<u8> {
-		self.encode()
 	}
 }

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -19,269 +19,462 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "v13")]
+mod v13;
+
 #[cfg(feature = "std")]
-use codec::Decode;
-use codec::Encode;
+use codec::{Decode, Error, Input};
+use codec::{Encode, Output};
+#[cfg(feature = "std")]
+use serde::Serialize;
 
-use scale_info::prelude::fmt::Debug;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
-use scale_info::{
-	form::{CompactForm, Form, FormString, MetaForm},
-	meta_type, IntoCompact, Registry, RegistryReadOnly, TypeInfo,
-};
+#[cfg(feature = "std")]
+type StringBuf = String;
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
-pub type RuntimeMetadataLastVersion<T> = RuntimeMetadataV12<T>;
+/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
+/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
+#[cfg(not(feature = "std"))]
+type StringBuf = &'static str;
 
-/// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct RuntimeMetadataPrefixed<S = &'static str>
+/// A type that decodes to a different type than it encodes.
+/// The user needs to make sure that both types use the same encoding.
+///
+/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
+#[derive(Clone)]
+pub enum DecodeDifferent<B, O>
 where
-	S: FormString,
+	B: 'static,
+	O: 'static,
 {
-	pub prefix: u32,
-	pub types: RegistryReadOnly<S>,
-	pub metadata: RuntimeMetadata<CompactForm<S>>,
+	Encode(B),
+	Decoded(O),
 }
 
-impl From<RuntimeMetadataLastVersion<MetaForm>> for RuntimeMetadataPrefixed {
-	fn from(metadata: RuntimeMetadataLastVersion<MetaForm>) -> RuntimeMetadataPrefixed {
-		let mut registry = Registry::new();
-		let metadata = metadata.into_compact(&mut registry);
-		RuntimeMetadataPrefixed {
-			prefix: META_RESERVED,
-			types: registry.into(),
-			metadata: RuntimeMetadata::V12(metadata),
+impl<B, O> Encode for DecodeDifferent<B, O>
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
+{
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		match self {
+			DecodeDifferent::Encode(b) => b.encode_to(dest),
+			DecodeDifferent::Decoded(o) => o.encode_to(dest),
 		}
 	}
+}
+
+impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
+{
+}
+
+#[cfg(feature = "std")]
+impl<B, O> Decode for DecodeDifferent<B, O>
+where
+	B: 'static,
+	O: Decode + 'static,
+{
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
+	}
+}
+
+impl<B, O> PartialEq for DecodeDifferent<B, O>
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
+{
+	fn eq(&self, other: &Self) -> bool {
+		self.encode() == other.encode()
+	}
+}
+
+impl<B, O> Eq for DecodeDifferent<B, O>
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
+{
+}
+
+impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
+where
+	B: core::fmt::Debug + Eq + 'static,
+	O: core::fmt::Debug + Eq + 'static,
+{
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		match self {
+			DecodeDifferent::Encode(b) => b.fmt(f),
+			DecodeDifferent::Decoded(o) => o.fmt(f),
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl<B, O> serde::Serialize for DecodeDifferent<B, O>
+where
+	B: serde::Serialize + 'static,
+	O: serde::Serialize + 'static,
+{
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		match self {
+			DecodeDifferent::Encode(b) => b.serialize(serializer),
+			DecodeDifferent::Decoded(o) => o.serialize(serializer),
+		}
+	}
+}
+
+pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
+
+type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
+
+/// All the metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionMetadata {
+	pub name: DecodeDifferentStr,
+	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionArgumentMetadata {
+	pub name: DecodeDifferentStr,
+	pub ty: DecodeDifferentStr,
+}
+
+/// Newtype wrapper for support encoding functions (actual the result of the function).
+#[derive(Clone, Eq)]
+pub struct FnEncode<E>(pub fn() -> E)
+where
+	E: Encode + 'static;
+
+impl<E: Encode> Encode for FnEncode<E> {
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		self.0().encode_to(dest);
+	}
+}
+
+impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
+
+impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
+	fn eq(&self, other: &Self) -> bool {
+		self.0().eq(&other.0())
+	}
+}
+
+impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.0().fmt(f)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.0().serialize(serializer)
+	}
+}
+
+/// All the metadata about an outer event.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct OuterEventMetadata {
+	pub name: DecodeDifferentStr,
+	pub events: DecodeDifferentArray<
+		(&'static str, FnEncode<&'static [EventMetadata]>),
+		(StringBuf, Vec<EventMetadata>),
+	>,
+}
+
+/// All the metadata about an event.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct EventMetadata {
+	pub name: DecodeDifferentStr,
+	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about one storage entry.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct StorageEntryMetadata {
+	pub name: DecodeDifferentStr,
+	pub modifier: StorageEntryModifier,
+	pub ty: StorageEntryType,
+	pub default: ByteGetter,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about one module constant.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ModuleConstantMetadata {
+	pub name: DecodeDifferentStr,
+	pub ty: DecodeDifferentStr,
+	pub value: ByteGetter,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about a module error.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ErrorMetadata {
+	pub name: DecodeDifferentStr,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about errors in a module.
+pub trait ModuleErrorMetadata {
+	fn metadata() -> &'static [ErrorMetadata];
+}
+
+impl ModuleErrorMetadata for &'static str {
+	fn metadata() -> &'static [ErrorMetadata] {
+		&[]
+	}
+}
+
+/// A technical trait to store lazy initiated vec value as static dyn pointer.
+pub trait DefaultByte: Send + Sync {
+	fn default_byte(&self) -> Vec<u8>;
+}
+
+/// Wrapper over dyn pointer for accessing a cached once byte value.
+#[derive(Clone)]
+pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
+
+/// Decode different for static lazy initiated byte value.
+pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
+
+impl Encode for DefaultByteGetter {
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		self.0.default_byte().encode_to(dest)
+	}
+}
+
+impl codec::EncodeLike for DefaultByteGetter {}
+
+impl PartialEq<DefaultByteGetter> for DefaultByteGetter {
+	fn eq(&self, other: &DefaultByteGetter) -> bool {
+		let left = self.0.default_byte();
+		let right = other.0.default_byte();
+		left.eq(&right)
+	}
+}
+
+impl Eq for DefaultByteGetter {}
+
+#[cfg(feature = "std")]
+impl serde::Serialize for DefaultByteGetter {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.0.default_byte().serialize(serializer)
+	}
+}
+
+impl core::fmt::Debug for DefaultByteGetter {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.0.default_byte().fmt(f)
+	}
+}
+
+/// Hasher used by storage maps
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageHasher {
+	Blake2_128,
+	Blake2_256,
+	Blake2_128Concat,
+	Twox128,
+	Twox256,
+	Twox64Concat,
+	Identity,
+}
+
+/// A storage entry type.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageEntryType {
+	Plain(DecodeDifferentStr),
+	Map {
+		hasher: StorageHasher,
+		key: DecodeDifferentStr,
+		value: DecodeDifferentStr,
+		// is_linked flag previously, unused now to keep backwards compat
+		unused: bool,
+	},
+	DoubleMap {
+		hasher: StorageHasher,
+		key1: DecodeDifferentStr,
+		key2: DecodeDifferentStr,
+		value: DecodeDifferentStr,
+		key2_hasher: StorageHasher,
+	},
+}
+
+/// A storage entry modifier.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageEntryModifier {
+	Optional,
+	Default,
+}
+
+/// All metadata of the storage.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct StorageMetadata {
+	/// The common prefix used by all storage entries.
+	pub prefix: DecodeDifferent<&'static str, StringBuf>,
+	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
+}
+
+/// Metadata prefixed by a u32 for reserved usage
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
+
+/// Metadata of the extrinsic used by the runtime.
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ExtrinsicMetadata {
+	/// Extrinsic version.
+	pub version: u8,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: Vec<DecodeDifferentStr>,
 }
 
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
-#[derive(Eq, Encode, PartialEq, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub enum RuntimeMetadata<T: Form = MetaForm> {
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum RuntimeMetadata {
+	/// Unused; enum filler.
+	V0(RuntimeMetadataDeprecated),
+	/// Version 1 for runtime metadata. No longer used.
+	V1(RuntimeMetadataDeprecated),
+	/// Version 2 for runtime metadata. No longer used.
+	V2(RuntimeMetadataDeprecated),
+	/// Version 3 for runtime metadata. No longer used.
+	V3(RuntimeMetadataDeprecated),
+	/// Version 4 for runtime metadata. No longer used.
+	V4(RuntimeMetadataDeprecated),
+	/// Version 5 for runtime metadata. No longer used.
+	V5(RuntimeMetadataDeprecated),
+	/// Version 6 for runtime metadata. No longer used.
+	V6(RuntimeMetadataDeprecated),
+	/// Version 7 for runtime metadata. No longer used.
+	V7(RuntimeMetadataDeprecated),
+	/// Version 8 for runtime metadata. No longer used.
+	V8(RuntimeMetadataDeprecated),
+	/// Version 9 for runtime metadata. No longer used.
+	V9(RuntimeMetadataDeprecated),
+	/// Version 10 for runtime metadata. No longer used.
+	V10(RuntimeMetadataDeprecated),
+	/// Version 11 for runtime metadata. No longer used.
+	V11(RuntimeMetadataDeprecated),
 	/// Version 12 for runtime metadata.
-	V12(RuntimeMetadataV12<T>),
+	#[cfg(feature = "v12")]
+	V12(RuntimeMetadataV12),
+	#[cfg(not(feature = "v12"))]
+	V12(RuntimeMetadataDeprecated),
+	#[cfg(feature = "v13")]
+	V13(RuntimeMetadataV13),
 }
 
-/// The metadata of a runtime.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct RuntimeMetadataV12<T: Form = MetaForm> {
-	/// Metadata of all the modules.
-	pub modules: Vec<ModuleMetadata<T>>,
-	// /// Metadata of the extrinsic.
-	// pub extrinsic: ExtrinsicMetadata<F>,
+/// Enum that should fail.
+#[derive(Eq, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Debug))]
+pub enum RuntimeMetadataDeprecated {}
+
+impl Encode for RuntimeMetadataDeprecated {
+	fn encode_to<W: Output>(&self, _dest: &mut W) {}
 }
 
-impl IntoCompact for RuntimeMetadataV12 {
-	type Output = RuntimeMetadataV12<CompactForm>;
+impl codec::EncodeLike for RuntimeMetadataDeprecated {}
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		RuntimeMetadataV12 {
-			modules: registry.map_into_compact(self.modules),
-			// extrinsic: self.extrinsic.into_compact(registry),
-		}
+#[cfg(feature = "std")]
+impl Decode for RuntimeMetadataDeprecated {
+	fn decode<I: Input>(_input: &mut I) -> Result<Self, Error> {
+		Err("Decoding is not supported".into())
 	}
 }
 
-/// Metadata of the extrinsic used by the runtime.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct ExtrinsicMetadata<T: Form = MetaForm> {
-	/// Extrinsic version.
-	pub version: u8,
-	/// The signed extensions in the order they appear in the extrinsic.
-	pub signed_extensions: Vec<T::Type>,
+/// The metadata of a runtime.
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg(feature = "v12")]
+pub struct RuntimeMetadataV12 {
+	/// Metadata of all the modules.
+	pub modules: DecodeDifferentArray<ModuleMetadata>,
+	/// Metadata of the extrinsic.
+	pub extrinsic: ExtrinsicMetadata,
 }
 
-impl IntoCompact for ExtrinsicMetadata {
-	type Output = ExtrinsicMetadata<CompactForm>;
+/// The latest version of the metadata.
+#[cfg(feature = "v12")]
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV12;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		ExtrinsicMetadata {
-			version: self.version,
-			signed_extensions: registry.register_types(self.signed_extensions),
-		}
+#[cfg(feature = "v12")]
+impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
+	fn into(self) -> RuntimeMetadataPrefixed {
+		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V12(self))
+	}
+}
+
+/// The latest version of the metadata.
+#[cfg(feature = "v13")]
+pub type RuntimeMetadataLastVersion = v13::RuntimeMetadataV13<scale_info::form::MetaForm>;
+
+#[cfg(feature = "v13")]
+impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
+	fn into(self) -> RuntimeMetadataPrefixed {
+		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V13(self))
 	}
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct ModuleMetadata<T: Form = MetaForm> {
-	pub name: T::String,
-	// pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
-	pub calls: Option<Vec<FunctionMetadata<T>>>,
-	pub event: Option<Vec<EventMetadata<T>>>,
-	// pub constants: DFnA<ModuleConstantMetadata>,
-	// pub errors: DFnA<ErrorMetadata>,
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ModuleMetadata {
+	pub name: DecodeDifferentStr,
+	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+	pub calls: ODFnA<FunctionMetadata>,
+	pub event: ODFnA<EventMetadata>,
+	pub constants: DFnA<ModuleConstantMetadata>,
+	pub errors: DFnA<ErrorMetadata>,
+	/// Define the index of the module, this index will be used for the encoding of module event,
+	/// call and origin variants.
+	pub index: u8,
 }
 
-impl IntoCompact for ModuleMetadata {
-	type Output = ModuleMetadata<CompactForm>;
+type ODFnA<T> = Option<DFnA<T>>;
+type DFnA<T> = DecodeDifferent<FnEncode<&'static [T]>, Vec<T>>;
 
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		ModuleMetadata {
-			name: self.name.into_compact(registry),
-			calls: self.calls.map(|calls| registry.map_into_compact(calls)),
-			event: self.event.map(|event| registry.map_into_compact(event)),
-		}
-	}
-}
-
-/// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct FunctionMetadata<T: Form = MetaForm> {
-	pub name: T::String,
-	pub arguments: Vec<FunctionArgumentMetadata<T>>,
-	pub documentation: Vec<T::String>,
-}
-
-impl IntoCompact for FunctionMetadata {
-	type Output = FunctionMetadata<CompactForm>;
-
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		FunctionMetadata {
-			name: self.name.into_compact(registry),
-			arguments: registry.map_into_compact(self.arguments),
-			documentation: registry.map_into_compact(self.documentation),
-		}
-	}
-}
-
-/// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
-	pub name: T::String,
-	pub ty: T::Type,
-	pub is_compact: bool,
-}
-
-impl IntoCompact for FunctionArgumentMetadata {
-	type Output = FunctionArgumentMetadata<CompactForm>;
-
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		FunctionArgumentMetadata {
-			name: self.name.into_compact(registry),
-			ty: registry.register_type(&self.ty),
-			is_compact: self.is_compact,
-		}
-	}
-}
-
-/// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct OuterEventMetadata<T: Form = MetaForm> {
-	pub name: T::String,
-	pub events: Vec<ModuleEventMetadata<T>>,
-}
-
-impl IntoCompact for OuterEventMetadata {
-	type Output = OuterEventMetadata<CompactForm>;
-
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		OuterEventMetadata {
-			name: self.name.into_compact(registry),
-			events: registry.map_into_compact(self.events),
-		}
-	}
-}
-
-/// Metadata about a module event.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct ModuleEventMetadata<T: Form = MetaForm> {
-	pub name: T::String,
-	pub events: Vec<EventMetadata<T>>,
-}
-
-impl IntoCompact for ModuleEventMetadata {
-	type Output = ModuleEventMetadata<CompactForm>;
-
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		ModuleEventMetadata {
-			name: self.name.into_compact(registry),
-			events: registry.map_into_compact(self.events),
-		}
-	}
-}
-
-/// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct EventMetadata<T: Form = MetaForm> {
-	pub name: T::String,
-	pub arguments: Vec<TypeSpec<T>>,
-	pub documentation: Vec<T::String>,
-}
-
-impl IntoCompact for EventMetadata {
-	type Output = EventMetadata<CompactForm>;
-
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		EventMetadata {
-			name: self.name.into_compact(registry),
-			arguments: registry.map_into_compact(self.arguments),
-			documentation: registry.map_into_compact(self.documentation),
-		}
-	}
-}
-
-/// A type specification.
-///
-/// This contains the actual type as well as an optional compile-time
-/// known displayed representation of the type. This is useful for cases
-/// where the type is used through a type alias in order to provide
-/// information about the alias name.
-///
-/// # Examples
-///
-/// Consider the following Rust function:
-/// ```no_compile
-/// fn is_sorted(input: &[i32], pred: Predicate) -> bool;
-/// ```
-/// In this above example `input` would have no displayable name,
-/// `pred`'s display name is `Predicate` and the display name of
-/// the return type is simply `bool`. Note that `Predicate` could
-/// simply be a type alias to `fn(i32, i32) -> Ordering`.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub struct TypeSpec<T: Form = MetaForm> {
-	/// The actual type.
-	pub ty: T::Type,
-	/// The compile-time known displayed representation of the type.
-	pub name: T::String,
-}
-
-impl IntoCompact for TypeSpec {
-	type Output = TypeSpec<CompactForm>;
-
-	fn into_compact(self, registry: &mut Registry) -> Self::Output {
-		TypeSpec {
-			ty: registry.register_type(&self.ty),
-			name: self.name.into_compact(registry),
-		}
-	}
-}
-
-impl TypeSpec {
-	/// Creates a new type specification without a display name.
-	pub fn new<T>(name: &'static str) -> Self
-	where
-		T: TypeInfo + 'static,
-	{
-		Self {
-			ty: meta_type::<T>(),
-			name,
-		}
+impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
+	fn into(self) -> Vec<u8> {
+		self.encode()
 	}
 }

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -17,8 +17,6 @@
 
 //! Decodable variant of the RuntimeMetadata.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 use codec::{Encode, Output};
 
 cfg_if::cfg_if! {
@@ -39,11 +37,6 @@ cfg_if::cfg_if! {
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
-
-/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
-/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
-#[cfg(not(feature = "std"))]
-type StringBuf = &'static str;
 
 /// A type that decodes to a different type than it encodes.
 /// The user needs to make sure that both types use the same encoding.
@@ -367,8 +360,8 @@ pub struct ExtrinsicMetadata {
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct RuntimeMetadataV12 {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -1,0 +1,404 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Decodable variant of the RuntimeMetadata.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Encode, Output};
+
+cfg_if::cfg_if! {
+	if #[cfg(feature = "std")] {
+		use codec::{Decode, Error, Input};
+		use serde::Serialize;
+
+		type StringBuf = String;
+	} else {
+		extern crate alloc;
+		use alloc::vec::Vec;
+
+		/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
+        /// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
+        type StringBuf = &'static str;
+	}
+}
+
+/// Current prefix of metadata
+pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
+
+/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
+/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
+#[cfg(not(feature = "std"))]
+type StringBuf = &'static str;
+
+/// A type that decodes to a different type than it encodes.
+/// The user needs to make sure that both types use the same encoding.
+///
+/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
+#[derive(Clone)]
+pub enum DecodeDifferent<B, O>
+    where
+        B: 'static,
+        O: 'static,
+{
+    Encode(B),
+    Decoded(O),
+}
+
+impl<B, O> Encode for DecodeDifferent<B, O>
+    where
+        B: Encode + 'static,
+        O: Encode + 'static,
+{
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        match self {
+            DecodeDifferent::Encode(b) => b.encode_to(dest),
+            DecodeDifferent::Decoded(o) => o.encode_to(dest),
+        }
+    }
+}
+
+impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
+    where
+        B: Encode + 'static,
+        O: Encode + 'static,
+{
+}
+
+#[cfg(feature = "std")]
+impl<B, O> Decode for DecodeDifferent<B, O>
+    where
+        B: 'static,
+        O: Decode + 'static,
+{
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        <O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
+    }
+}
+
+impl<B, O> PartialEq for DecodeDifferent<B, O>
+    where
+        B: Encode + Eq + PartialEq + 'static,
+        O: Encode + Eq + PartialEq + 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.encode() == other.encode()
+    }
+}
+
+impl<B, O> Eq for DecodeDifferent<B, O>
+    where
+        B: Encode + Eq + PartialEq + 'static,
+        O: Encode + Eq + PartialEq + 'static,
+{
+}
+
+impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
+    where
+        B: core::fmt::Debug + Eq + 'static,
+        O: core::fmt::Debug + Eq + 'static,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            DecodeDifferent::Encode(b) => b.fmt(f),
+            DecodeDifferent::Decoded(o) => o.fmt(f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<B, O> serde::Serialize for DecodeDifferent<B, O>
+    where
+        B: serde::Serialize + 'static,
+        O: serde::Serialize + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+    {
+        match self {
+            DecodeDifferent::Encode(b) => b.serialize(serializer),
+            DecodeDifferent::Decoded(o) => o.serialize(serializer),
+        }
+    }
+}
+
+pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
+
+type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
+
+/// All the metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionMetadata {
+    pub name: DecodeDifferentStr,
+    pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionArgumentMetadata {
+    pub name: DecodeDifferentStr,
+    pub ty: DecodeDifferentStr,
+}
+
+/// Newtype wrapper for support encoding functions (actual the result of the function).
+#[derive(Clone, Eq)]
+pub struct FnEncode<E>(pub fn() -> E)
+    where
+        E: Encode + 'static;
+
+impl<E: Encode> Encode for FnEncode<E> {
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        self.0().encode_to(dest);
+    }
+}
+
+impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
+
+impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0().eq(&other.0())
+    }
+}
+
+impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.0().fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+    {
+        self.0().serialize(serializer)
+    }
+}
+
+/// All the metadata about an outer event.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct OuterEventMetadata {
+    pub name: DecodeDifferentStr,
+    pub events: DecodeDifferentArray<
+        (&'static str, FnEncode<&'static [EventMetadata]>),
+        (StringBuf, Vec<EventMetadata>),
+    >,
+}
+
+/// All the metadata about an event.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct EventMetadata {
+    pub name: DecodeDifferentStr,
+    pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
+    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about one storage entry.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct StorageEntryMetadata {
+    pub name: DecodeDifferentStr,
+    pub modifier: StorageEntryModifier,
+    pub ty: StorageEntryType,
+    pub default: ByteGetter,
+    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about one module constant.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ModuleConstantMetadata {
+    pub name: DecodeDifferentStr,
+    pub ty: DecodeDifferentStr,
+    pub value: ByteGetter,
+    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about a module error.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ErrorMetadata {
+    pub name: DecodeDifferentStr,
+    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about errors in a module.
+pub trait ModuleErrorMetadata {
+    fn metadata() -> &'static [ErrorMetadata];
+}
+
+impl ModuleErrorMetadata for &'static str {
+    fn metadata() -> &'static [ErrorMetadata] {
+        &[]
+    }
+}
+
+/// A technical trait to store lazy initiated vec value as static dyn pointer.
+pub trait DefaultByte: Send + Sync {
+    fn default_byte(&self) -> Vec<u8>;
+}
+
+/// Wrapper over dyn pointer for accessing a cached once byte value.
+#[derive(Clone)]
+pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
+
+/// Decode different for static lazy initiated byte value.
+pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
+
+impl Encode for DefaultByteGetter {
+    fn encode_to<W: Output>(&self, dest: &mut W) {
+        self.0.default_byte().encode_to(dest)
+    }
+}
+
+impl codec::EncodeLike for DefaultByteGetter {}
+
+impl PartialEq<DefaultByteGetter> for DefaultByteGetter {
+    fn eq(&self, other: &DefaultByteGetter) -> bool {
+        let left = self.0.default_byte();
+        let right = other.0.default_byte();
+        left.eq(&right)
+    }
+}
+
+impl Eq for DefaultByteGetter {}
+
+#[cfg(feature = "std")]
+impl serde::Serialize for DefaultByteGetter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+    {
+        self.0.default_byte().serialize(serializer)
+    }
+}
+
+impl core::fmt::Debug for DefaultByteGetter {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.0.default_byte().fmt(f)
+    }
+}
+
+/// Hasher used by storage maps
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageHasher {
+    Blake2_128,
+    Blake2_256,
+    Blake2_128Concat,
+    Twox128,
+    Twox256,
+    Twox64Concat,
+    Identity,
+}
+
+/// A storage entry type.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageEntryType {
+    Plain(DecodeDifferentStr),
+    Map {
+        hasher: StorageHasher,
+        key: DecodeDifferentStr,
+        value: DecodeDifferentStr,
+        // is_linked flag previously, unused now to keep backwards compat
+        unused: bool,
+    },
+    DoubleMap {
+        hasher: StorageHasher,
+        key1: DecodeDifferentStr,
+        key2: DecodeDifferentStr,
+        value: DecodeDifferentStr,
+        key2_hasher: StorageHasher,
+    },
+}
+
+/// A storage entry modifier.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageEntryModifier {
+    Optional,
+    Default,
+}
+
+/// All metadata of the storage.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct StorageMetadata {
+    /// The common prefix used by all storage entries.
+    pub prefix: DecodeDifferent<&'static str, StringBuf>,
+    pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
+}
+
+/// Metadata prefixed by a u32 for reserved usage
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct RuntimeMetadataPrefixed(pub u32, pub super::RuntimeMetadata);
+
+/// Metadata of the extrinsic used by the runtime.
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ExtrinsicMetadata {
+    /// Extrinsic version.
+    pub version: u8,
+    /// The signed extensions in the order they appear in the extrinsic.
+    pub signed_extensions: Vec<DecodeDifferentStr>,
+}
+
+/// The metadata of a runtime.
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
+pub struct RuntimeMetadataV12 {
+    /// Metadata of all the modules.
+    pub modules: DecodeDifferentArray<ModuleMetadata>,
+    /// Metadata of the extrinsic.
+    pub extrinsic: ExtrinsicMetadata,
+}
+
+/// The latest version of the metadata.
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV12;
+
+/// All metadata about an runtime module.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct ModuleMetadata {
+    pub name: DecodeDifferentStr,
+    pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+    pub calls: ODFnA<FunctionMetadata>,
+    pub event: ODFnA<EventMetadata>,
+    pub constants: DFnA<ModuleConstantMetadata>,
+    pub errors: DFnA<ErrorMetadata>,
+    /// Define the index of the module, this index will be used for the encoding of module event,
+    /// call and origin variants.
+    pub index: u8,
+}
+
+type ODFnA<T> = Option<DFnA<T>>;
+type DFnA<T> = DecodeDifferent<FnEncode<&'static [T]>, Vec<T>>;
+
+impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
+    fn into(self) -> Vec<u8> {
+        self.encode()
+    }
+}

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -32,8 +32,8 @@ cfg_if::cfg_if! {
 		use alloc::vec::Vec;
 
 		/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
-        /// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
-        type StringBuf = &'static str;
+		/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
+		type StringBuf = &'static str;
 	}
 }
 
@@ -51,90 +51,90 @@ type StringBuf = &'static str;
 /// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
 #[derive(Clone)]
 pub enum DecodeDifferent<B, O>
-    where
-        B: 'static,
-        O: 'static,
+where
+	B: 'static,
+	O: 'static,
 {
-    Encode(B),
-    Decoded(O),
+	Encode(B),
+	Decoded(O),
 }
 
 impl<B, O> Encode for DecodeDifferent<B, O>
-    where
-        B: Encode + 'static,
-        O: Encode + 'static,
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
 {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        match self {
-            DecodeDifferent::Encode(b) => b.encode_to(dest),
-            DecodeDifferent::Decoded(o) => o.encode_to(dest),
-        }
-    }
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		match self {
+			DecodeDifferent::Encode(b) => b.encode_to(dest),
+			DecodeDifferent::Decoded(o) => o.encode_to(dest),
+		}
+	}
 }
 
 impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
-    where
-        B: Encode + 'static,
-        O: Encode + 'static,
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
 {
 }
 
 #[cfg(feature = "std")]
 impl<B, O> Decode for DecodeDifferent<B, O>
-    where
-        B: 'static,
-        O: Decode + 'static,
+where
+	B: 'static,
+	O: Decode + 'static,
 {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-        <O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
-    }
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
+	}
 }
 
 impl<B, O> PartialEq for DecodeDifferent<B, O>
-    where
-        B: Encode + Eq + PartialEq + 'static,
-        O: Encode + Eq + PartialEq + 'static,
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
 {
-    fn eq(&self, other: &Self) -> bool {
-        self.encode() == other.encode()
-    }
+	fn eq(&self, other: &Self) -> bool {
+		self.encode() == other.encode()
+	}
 }
 
 impl<B, O> Eq for DecodeDifferent<B, O>
-    where
-        B: Encode + Eq + PartialEq + 'static,
-        O: Encode + Eq + PartialEq + 'static,
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
 {
 }
 
 impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
-    where
-        B: core::fmt::Debug + Eq + 'static,
-        O: core::fmt::Debug + Eq + 'static,
+where
+	B: core::fmt::Debug + Eq + 'static,
+	O: core::fmt::Debug + Eq + 'static,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        match self {
-            DecodeDifferent::Encode(b) => b.fmt(f),
-            DecodeDifferent::Decoded(o) => o.fmt(f),
-        }
-    }
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		match self {
+			DecodeDifferent::Encode(b) => b.fmt(f),
+			DecodeDifferent::Decoded(o) => o.fmt(f),
+		}
+	}
 }
 
 #[cfg(feature = "std")]
 impl<B, O> serde::Serialize for DecodeDifferent<B, O>
-    where
-        B: serde::Serialize + 'static,
-        O: serde::Serialize + 'static,
+where
+	B: serde::Serialize + 'static,
+	O: serde::Serialize + 'static,
 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
-    {
-        match self {
-            DecodeDifferent::Encode(b) => b.serialize(serializer),
-            DecodeDifferent::Decoded(o) => o.serialize(serializer),
-        }
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		match self {
+			DecodeDifferent::Encode(b) => b.serialize(serializer),
+			DecodeDifferent::Decoded(o) => o.serialize(serializer),
+		}
+	}
 }
 
 pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
@@ -145,118 +145,118 @@ type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct FunctionMetadata {
-    pub name: DecodeDifferentStr,
-    pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
-    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+	pub name: DecodeDifferentStr,
+	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// All the metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct FunctionArgumentMetadata {
-    pub name: DecodeDifferentStr,
-    pub ty: DecodeDifferentStr,
+	pub name: DecodeDifferentStr,
+	pub ty: DecodeDifferentStr,
 }
 
 /// Newtype wrapper for support encoding functions (actual the result of the function).
 #[derive(Clone, Eq)]
 pub struct FnEncode<E>(pub fn() -> E)
-    where
-        E: Encode + 'static;
+where
+	E: Encode + 'static;
 
 impl<E: Encode> Encode for FnEncode<E> {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        self.0().encode_to(dest);
-    }
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		self.0().encode_to(dest);
+	}
 }
 
 impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
 
 impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0().eq(&other.0())
-    }
+	fn eq(&self, other: &Self) -> bool {
+		self.0().eq(&other.0())
+	}
 }
 
 impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        self.0().fmt(f)
-    }
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.0().fmt(f)
+	}
 }
 
 #[cfg(feature = "std")]
 impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
-    {
-        self.0().serialize(serializer)
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.0().serialize(serializer)
+	}
 }
 
 /// All the metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct OuterEventMetadata {
-    pub name: DecodeDifferentStr,
-    pub events: DecodeDifferentArray<
-        (&'static str, FnEncode<&'static [EventMetadata]>),
-        (StringBuf, Vec<EventMetadata>),
-    >,
+	pub name: DecodeDifferentStr,
+	pub events: DecodeDifferentArray<
+		(&'static str, FnEncode<&'static [EventMetadata]>),
+		(StringBuf, Vec<EventMetadata>),
+	>,
 }
 
 /// All the metadata about an event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct EventMetadata {
-    pub name: DecodeDifferentStr,
-    pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
-    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+	pub name: DecodeDifferentStr,
+	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// All the metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct StorageEntryMetadata {
-    pub name: DecodeDifferentStr,
-    pub modifier: StorageEntryModifier,
-    pub ty: StorageEntryType,
-    pub default: ByteGetter,
-    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+	pub name: DecodeDifferentStr,
+	pub modifier: StorageEntryModifier,
+	pub ty: StorageEntryType,
+	pub default: ByteGetter,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// All the metadata about one module constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct ModuleConstantMetadata {
-    pub name: DecodeDifferentStr,
-    pub ty: DecodeDifferentStr,
-    pub value: ByteGetter,
-    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+	pub name: DecodeDifferentStr,
+	pub ty: DecodeDifferentStr,
+	pub value: ByteGetter,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// All the metadata about a module error.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct ErrorMetadata {
-    pub name: DecodeDifferentStr,
-    pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+	pub name: DecodeDifferentStr,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// All the metadata about errors in a module.
 pub trait ModuleErrorMetadata {
-    fn metadata() -> &'static [ErrorMetadata];
+	fn metadata() -> &'static [ErrorMetadata];
 }
 
 impl ModuleErrorMetadata for &'static str {
-    fn metadata() -> &'static [ErrorMetadata] {
-        &[]
-    }
+	fn metadata() -> &'static [ErrorMetadata] {
+		&[]
+	}
 }
 
 /// A technical trait to store lazy initiated vec value as static dyn pointer.
 pub trait DefaultByte: Send + Sync {
-    fn default_byte(&self) -> Vec<u8>;
+	fn default_byte(&self) -> Vec<u8>;
 }
 
 /// Wrapper over dyn pointer for accessing a cached once byte value.
@@ -267,88 +267,88 @@ pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
 pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
 
 impl Encode for DefaultByteGetter {
-    fn encode_to<W: Output>(&self, dest: &mut W) {
-        self.0.default_byte().encode_to(dest)
-    }
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		self.0.default_byte().encode_to(dest)
+	}
 }
 
 impl codec::EncodeLike for DefaultByteGetter {}
 
 impl PartialEq<DefaultByteGetter> for DefaultByteGetter {
-    fn eq(&self, other: &DefaultByteGetter) -> bool {
-        let left = self.0.default_byte();
-        let right = other.0.default_byte();
-        left.eq(&right)
-    }
+	fn eq(&self, other: &DefaultByteGetter) -> bool {
+		let left = self.0.default_byte();
+		let right = other.0.default_byte();
+		left.eq(&right)
+	}
 }
 
 impl Eq for DefaultByteGetter {}
 
 #[cfg(feature = "std")]
 impl serde::Serialize for DefaultByteGetter {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
-    {
-        self.0.default_byte().serialize(serializer)
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.0.default_byte().serialize(serializer)
+	}
 }
 
 impl core::fmt::Debug for DefaultByteGetter {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        self.0.default_byte().fmt(f)
-    }
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.0.default_byte().fmt(f)
+	}
 }
 
 /// Hasher used by storage maps
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageHasher {
-    Blake2_128,
-    Blake2_256,
-    Blake2_128Concat,
-    Twox128,
-    Twox256,
-    Twox64Concat,
-    Identity,
+	Blake2_128,
+	Blake2_256,
+	Blake2_128Concat,
+	Twox128,
+	Twox256,
+	Twox64Concat,
+	Identity,
 }
 
 /// A storage entry type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryType {
-    Plain(DecodeDifferentStr),
-    Map {
-        hasher: StorageHasher,
-        key: DecodeDifferentStr,
-        value: DecodeDifferentStr,
-        // is_linked flag previously, unused now to keep backwards compat
-        unused: bool,
-    },
-    DoubleMap {
-        hasher: StorageHasher,
-        key1: DecodeDifferentStr,
-        key2: DecodeDifferentStr,
-        value: DecodeDifferentStr,
-        key2_hasher: StorageHasher,
-    },
+	Plain(DecodeDifferentStr),
+	Map {
+		hasher: StorageHasher,
+		key: DecodeDifferentStr,
+		value: DecodeDifferentStr,
+		// is_linked flag previously, unused now to keep backwards compat
+		unused: bool,
+	},
+	DoubleMap {
+		hasher: StorageHasher,
+		key1: DecodeDifferentStr,
+		key2: DecodeDifferentStr,
+		value: DecodeDifferentStr,
+		key2_hasher: StorageHasher,
+	},
 }
 
 /// A storage entry modifier.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {
-    Optional,
-    Default,
+	Optional,
+	Default,
 }
 
 /// All metadata of the storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct StorageMetadata {
-    /// The common prefix used by all storage entries.
-    pub prefix: DecodeDifferent<&'static str, StringBuf>,
-    pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
+	/// The common prefix used by all storage entries.
+	pub prefix: DecodeDifferent<&'static str, StringBuf>,
+	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
 }
 
 /// Metadata prefixed by a u32 for reserved usage
@@ -360,20 +360,20 @@ pub struct RuntimeMetadataPrefixed(pub u32, pub super::RuntimeMetadata);
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct ExtrinsicMetadata {
-    /// Extrinsic version.
-    pub version: u8,
-    /// The signed extensions in the order they appear in the extrinsic.
-    pub signed_extensions: Vec<DecodeDifferentStr>,
+	/// Extrinsic version.
+	pub version: u8,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: Vec<DecodeDifferentStr>,
 }
 
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV12 {
-    /// Metadata of all the modules.
-    pub modules: DecodeDifferentArray<ModuleMetadata>,
-    /// Metadata of the extrinsic.
-    pub extrinsic: ExtrinsicMetadata,
+	/// Metadata of all the modules.
+	pub modules: DecodeDifferentArray<ModuleMetadata>,
+	/// Metadata of the extrinsic.
+	pub extrinsic: ExtrinsicMetadata,
 }
 
 /// The latest version of the metadata.
@@ -383,22 +383,22 @@ pub type RuntimeMetadataLastVersion = RuntimeMetadataV12;
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct ModuleMetadata {
-    pub name: DecodeDifferentStr,
-    pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
-    pub calls: ODFnA<FunctionMetadata>,
-    pub event: ODFnA<EventMetadata>,
-    pub constants: DFnA<ModuleConstantMetadata>,
-    pub errors: DFnA<ErrorMetadata>,
-    /// Define the index of the module, this index will be used for the encoding of module event,
-    /// call and origin variants.
-    pub index: u8,
+	pub name: DecodeDifferentStr,
+	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+	pub calls: ODFnA<FunctionMetadata>,
+	pub event: ODFnA<EventMetadata>,
+	pub constants: DFnA<ModuleConstantMetadata>,
+	pub errors: DFnA<ErrorMetadata>,
+	/// Define the index of the module, this index will be used for the encoding of module event,
+	/// call and origin variants.
+	pub index: u8,
 }
 
 type ODFnA<T> = Option<DFnA<T>>;
 type DFnA<T> = DecodeDifferent<FnEncode<&'static [T]>, Vec<T>>;
 
 impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
-    fn into(self) -> Vec<u8> {
-        self.encode()
-    }
+	fn into(self) -> Vec<u8> {
+		self.encode()
+	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -16,18 +16,18 @@
 // limitations under the License.
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        use codec::{Decode, Error, Input};
-        use serde::Serialize;
-    }
+	if #[cfg(feature = "std")] {
+		use codec::{Decode, Error, Input};
+		use serde::Serialize;
+	}
 }
 
-use scale_info::{
-    form::{PortableForm, Form, FormString, MetaForm},
-    meta_type, IntoPortable, Registry, PortableRegistry, TypeInfo,
-};
-use scale_info::prelude::vec::Vec;
 use codec::Encode;
+use scale_info::prelude::vec::Vec;
+use scale_info::{
+	form::{Form, FormString, MetaForm, PortableForm},
+	meta_type, IntoPortable, PortableRegistry, Registry, TypeInfo,
+};
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
@@ -40,9 +40,9 @@ pub struct RuntimeMetadataPrefixed(pub u32, pub super::RuntimeMetadata);
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV13;
 
 impl From<RuntimeMetadataLastVersion> for RuntimeMetadataPrefixed {
-    fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
-        RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V13(metadata))
-    }
+	fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
+		RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V13(metadata))
+	}
 }
 
 /// The metadata of a runtime.
@@ -50,168 +50,168 @@ impl From<RuntimeMetadataLastVersion> for RuntimeMetadataPrefixed {
 #[derive(PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct RuntimeMetadataV13<S: FormString = &'static str> {
-    pub types: PortableRegistry<S>,
-    /// Metadata of all the modules.
-    pub modules: Vec<ModuleMetadata<PortableForm>>,
-    // /// Metadata of the extrinsic.
-    // pub extrinsic: ExtrinsicMetadata<F>,
+	pub types: PortableRegistry<S>,
+	/// Metadata of all the modules.
+	pub modules: Vec<ModuleMetadata<PortableForm>>,
+	// /// Metadata of the extrinsic.
+	// pub extrinsic: ExtrinsicMetadata<F>,
 }
 
 impl RuntimeMetadataV13 {
-    pub fn new(modules: Vec<ModuleMetadata>) -> Self {
-        let mut registry = Registry::new();
-        let modules = registry.map_into_portable(modules);
-        Self {
-            types: registry.into(),
-            modules,
-        }
-    }
+	pub fn new(modules: Vec<ModuleMetadata>) -> Self {
+		let mut registry = Registry::new();
+		let modules = registry.map_into_portable(modules);
+		Self {
+			types: registry.into(),
+			modules,
+		}
+	}
 }
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
-    /// Extrinsic version.
-    pub version: u8,
-    /// The signed extensions in the order they appear in the extrinsic.
-    pub signed_extensions: Vec<T::Type>,
+	/// Extrinsic version.
+	pub version: u8,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: Vec<T::Type>,
 }
 
 impl IntoPortable for ExtrinsicMetadata {
-    type Output = ExtrinsicMetadata<PortableForm>;
+	type Output = ExtrinsicMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        ExtrinsicMetadata {
-            version: self.version,
-            signed_extensions: registry.register_types(self.signed_extensions),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		ExtrinsicMetadata {
+			version: self.version,
+			signed_extensions: registry.register_types(self.signed_extensions),
+		}
+	}
 }
 
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct ModuleMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    // pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
-    pub calls: Option<Vec<FunctionMetadata<T>>>,
-    pub event: Option<Vec<EventMetadata<T>>>,
-    // pub constants: DFnA<ModuleConstantMetadata>,
-    // pub errors: DFnA<ErrorMetadata>,
+	pub name: T::String,
+	// pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+	pub calls: Option<Vec<FunctionMetadata<T>>>,
+	pub event: Option<Vec<EventMetadata<T>>>,
+	// pub constants: DFnA<ModuleConstantMetadata>,
+	// pub errors: DFnA<ErrorMetadata>,
 }
 
 impl IntoPortable for ModuleMetadata {
-    type Output = ModuleMetadata<PortableForm>;
+	type Output = ModuleMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        ModuleMetadata {
-            name: self.name.into_portable(registry),
-            calls: self.calls.map(|calls| registry.map_into_portable(calls)),
-            event: self.event.map(|event| registry.map_into_portable(event)),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		ModuleMetadata {
+			name: self.name.into_portable(registry),
+			calls: self.calls.map(|calls| registry.map_into_portable(calls)),
+			event: self.event.map(|event| registry.map_into_portable(event)),
+		}
+	}
 }
 
 /// All the metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct FunctionMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub arguments: Vec<FunctionArgumentMetadata<T>>,
-    pub documentation: Vec<T::String>,
+	pub name: T::String,
+	pub arguments: Vec<FunctionArgumentMetadata<T>>,
+	pub documentation: Vec<T::String>,
 }
 
 impl IntoPortable for FunctionMetadata {
-    type Output = FunctionMetadata<PortableForm>;
+	type Output = FunctionMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        FunctionMetadata {
-            name: self.name.into_portable(registry),
-            arguments: registry.map_into_portable(self.arguments),
-            documentation: registry.map_into_portable(self.documentation),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		FunctionMetadata {
+			name: self.name.into_portable(registry),
+			arguments: registry.map_into_portable(self.arguments),
+			documentation: registry.map_into_portable(self.documentation),
+		}
+	}
 }
 
 /// All the metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub ty: T::Type,
-    pub is_compact: bool,
+	pub name: T::String,
+	pub ty: T::Type,
+	pub is_compact: bool,
 }
 
 impl IntoPortable for FunctionArgumentMetadata {
-    type Output = FunctionArgumentMetadata<PortableForm>;
+	type Output = FunctionArgumentMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        FunctionArgumentMetadata {
-            name: self.name.into_portable(registry),
-            ty: registry.register_type(&self.ty),
-            is_compact: self.is_compact,
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		FunctionArgumentMetadata {
+			name: self.name.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+			is_compact: self.is_compact,
+		}
+	}
 }
 
 /// All the metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct OuterEventMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub events: Vec<ModuleEventMetadata<T>>,
+	pub name: T::String,
+	pub events: Vec<ModuleEventMetadata<T>>,
 }
 
 impl IntoPortable for OuterEventMetadata {
-    type Output = OuterEventMetadata<PortableForm>;
+	type Output = OuterEventMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        OuterEventMetadata {
-            name: self.name.into_portable(registry),
-            events: registry.map_into_portable(self.events),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		OuterEventMetadata {
+			name: self.name.into_portable(registry),
+			events: registry.map_into_portable(self.events),
+		}
+	}
 }
 
 /// Metadata about a module event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct ModuleEventMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub events: Vec<EventMetadata<T>>,
+	pub name: T::String,
+	pub events: Vec<EventMetadata<T>>,
 }
 
 impl IntoPortable for ModuleEventMetadata {
-    type Output = ModuleEventMetadata<PortableForm>;
+	type Output = ModuleEventMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        ModuleEventMetadata {
-            name: self.name.into_portable(registry),
-            events: registry.map_into_portable(self.events),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		ModuleEventMetadata {
+			name: self.name.into_portable(registry),
+			events: registry.map_into_portable(self.events),
+		}
+	}
 }
 
 /// All the metadata about an event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct EventMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub arguments: Vec<TypeSpec<T>>,
-    pub documentation: Vec<T::String>,
+	pub name: T::String,
+	pub arguments: Vec<TypeSpec<T>>,
+	pub documentation: Vec<T::String>,
 }
 
 impl IntoPortable for EventMetadata {
-    type Output = EventMetadata<PortableForm>;
+	type Output = EventMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        EventMetadata {
-            name: self.name.into_portable(registry),
-            arguments: registry.map_into_portable(self.arguments),
-            documentation: registry.map_into_portable(self.documentation),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		EventMetadata {
+			name: self.name.into_portable(registry),
+			arguments: registry.map_into_portable(self.arguments),
+			documentation: registry.map_into_portable(self.documentation),
+		}
+	}
 }
 
 /// A type specification.
@@ -234,32 +234,32 @@ impl IntoPortable for EventMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub struct TypeSpec<T: Form = MetaForm> {
-    /// The actual type.
-    pub ty: T::Type,
-    /// The compile-time known displayed representation of the type.
-    pub name: T::String,
+	/// The actual type.
+	pub ty: T::Type,
+	/// The compile-time known displayed representation of the type.
+	pub name: T::String,
 }
 
 impl IntoPortable for TypeSpec {
-    type Output = TypeSpec<PortableForm>;
+	type Output = TypeSpec<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        TypeSpec {
-            ty: registry.register_type(&self.ty),
-            name: self.name.into_portable(registry),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		TypeSpec {
+			ty: registry.register_type(&self.ty),
+			name: self.name.into_portable(registry),
+		}
+	}
 }
 
 impl TypeSpec {
-    /// Creates a new type specification without a display name.
-    pub fn new<T>(name: &'static str) -> Self
-        where
-            T: TypeInfo + 'static,
-    {
-        Self {
-            ty: meta_type::<T>(),
-            name,
-        }
-    }
+	/// Creates a new type specification without a display name.
+	pub fn new<T>(name: &'static str) -> Self
+	where
+		T: TypeInfo + 'static,
+	{
+		Self {
+			ty: meta_type::<T>(),
+			name,
+		}
+	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -53,17 +53,19 @@ pub struct RuntimeMetadataV13<S: FormString = &'static str> {
 	pub types: PortableRegistry<S>,
 	/// Metadata of all the modules.
 	pub modules: Vec<ModuleMetadata<PortableForm>>,
-	// /// Metadata of the extrinsic.
-	// pub extrinsic: ExtrinsicMetadata<F>,
+	/// Metadata of the extrinsic.
+	pub extrinsic: ExtrinsicMetadata<PortableForm>,
 }
 
 impl RuntimeMetadataV13 {
-	pub fn new(modules: Vec<ModuleMetadata>) -> Self {
+	pub fn new(modules: Vec<ModuleMetadata>, extrinsic: ExtrinsicMetadata) -> Self {
 		let mut registry = Registry::new();
 		let modules = registry.map_into_portable(modules);
+		let extrinsic = extrinsic.into_portable(&mut registry);
 		Self {
 			types: registry.into(),
 			modules,
+			extrinsic,
 		}
 	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -1,0 +1,257 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use scale_info::{
+    form::{CompactForm, Form, FormString, MetaForm},
+    meta_type, IntoCompact, Registry, RegistryReadOnly, TypeInfo,
+};
+
+impl From<RuntimeMetadataLastVersion<MetaForm>> for RuntimeMetadataPrefixed {
+    fn from(metadata: RuntimeMetadataLastVersion<MetaForm>) -> RuntimeMetadataPrefixed {
+        let mut registry = Registry::new();
+        let metadata = metadata.into_compact(&mut registry);
+        RuntimeMetadataPrefixed {
+            prefix: super::META_RESERVED,
+            types: registry.into(),
+            metadata: RuntimeMetadata::V12(metadata),
+        }
+    }
+}
+
+/// The metadata of a runtime.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct RuntimeMetadataV13<T: Form = MetaForm> {
+    pub types: RegistryReadOnly<S>,
+    /// Metadata of all the modules.
+    pub modules: Vec<ModuleMetadata<T>>,
+    // /// Metadata of the extrinsic.
+    // pub extrinsic: ExtrinsicMetadata<F>,
+}
+
+impl RuntimeMetadataV13 {
+    pub fn new(modules: Vec<ModuleMetadata>) -> Self {
+
+    }
+}
+
+impl IntoCompact for RuntimeMetadataV13 {
+    type Output = RuntimeMetadataV13<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        RuntimeMetadataV13 {
+            modules: registry.map_into_compact(self.modules),
+            // extrinsic: self.extrinsic.into_compact(registry),
+        }
+    }
+}
+
+/// Metadata of the extrinsic used by the runtime.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct ExtrinsicMetadata<T: Form = MetaForm> {
+    /// Extrinsic version.
+    pub version: u8,
+    /// The signed extensions in the order they appear in the extrinsic.
+    pub signed_extensions: Vec<T::Type>,
+}
+
+impl IntoCompact for ExtrinsicMetadata {
+    type Output = ExtrinsicMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        ExtrinsicMetadata {
+            version: self.version,
+            signed_extensions: registry.register_types(self.signed_extensions),
+        }
+    }
+}
+
+/// All metadata about an runtime module.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct ModuleMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    // pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+    pub calls: Option<Vec<FunctionMetadata<T>>>,
+    pub event: Option<Vec<EventMetadata<T>>>,
+    // pub constants: DFnA<ModuleConstantMetadata>,
+    // pub errors: DFnA<ErrorMetadata>,
+}
+
+impl IntoCompact for ModuleMetadata {
+    type Output = ModuleMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        ModuleMetadata {
+            name: self.name.into_compact(registry),
+            calls: self.calls.map(|calls| registry.map_into_compact(calls)),
+            event: self.event.map(|event| registry.map_into_compact(event)),
+        }
+    }
+}
+
+/// All the metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct FunctionMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub arguments: Vec<FunctionArgumentMetadata<T>>,
+    pub documentation: Vec<T::String>,
+}
+
+impl IntoCompact for FunctionMetadata {
+    type Output = FunctionMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        FunctionMetadata {
+            name: self.name.into_compact(registry),
+            arguments: registry.map_into_compact(self.arguments),
+            documentation: registry.map_into_compact(self.documentation),
+        }
+    }
+}
+
+/// All the metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub ty: T::Type,
+    pub is_compact: bool,
+}
+
+impl IntoCompact for FunctionArgumentMetadata {
+    type Output = FunctionArgumentMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        FunctionArgumentMetadata {
+            name: self.name.into_compact(registry),
+            ty: registry.register_type(&self.ty),
+            is_compact: self.is_compact,
+        }
+    }
+}
+
+/// All the metadata about an outer event.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct OuterEventMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub events: Vec<ModuleEventMetadata<T>>,
+}
+
+impl IntoCompact for OuterEventMetadata {
+    type Output = OuterEventMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        OuterEventMetadata {
+            name: self.name.into_compact(registry),
+            events: registry.map_into_compact(self.events),
+        }
+    }
+}
+
+/// Metadata about a module event.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct ModuleEventMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub events: Vec<EventMetadata<T>>,
+}
+
+impl IntoCompact for ModuleEventMetadata {
+    type Output = ModuleEventMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        ModuleEventMetadata {
+            name: self.name.into_compact(registry),
+            events: registry.map_into_compact(self.events),
+        }
+    }
+}
+
+/// All the metadata about an event.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct EventMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub arguments: Vec<TypeSpec<T>>,
+    pub documentation: Vec<T::String>,
+}
+
+impl IntoCompact for EventMetadata {
+    type Output = EventMetadata<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        EventMetadata {
+            name: self.name.into_compact(registry),
+            arguments: registry.map_into_compact(self.arguments),
+            documentation: registry.map_into_compact(self.documentation),
+        }
+    }
+}
+
+/// A type specification.
+///
+/// This contains the actual type as well as an optional compile-time
+/// known displayed representation of the type. This is useful for cases
+/// where the type is used through a type alias in order to provide
+/// information about the alias name.
+///
+/// # Examples
+///
+/// Consider the following Rust function:
+/// ```no_compile
+/// fn is_sorted(input: &[i32], pred: Predicate) -> bool;
+/// ```
+/// In this above example `input` would have no displayable name,
+/// `pred`'s display name is `Predicate` and the display name of
+/// the return type is simply `bool`. Note that `Predicate` could
+/// simply be a type alias to `fn(i32, i32) -> Ordering`.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub struct TypeSpec<T: Form = MetaForm> {
+    /// The actual type.
+    pub ty: T::Type,
+    /// The compile-time known displayed representation of the type.
+    pub name: T::String,
+}
+
+impl IntoCompact for TypeSpec {
+    type Output = TypeSpec<CompactForm>;
+
+    fn into_compact(self, registry: &mut Registry) -> Self::Output {
+        TypeSpec {
+            ty: registry.register_type(&self.ty),
+            name: self.name.into_compact(registry),
+        }
+    }
+}
+
+impl TypeSpec {
+    /// Creates a new type specification without a display name.
+    pub fn new<T>(name: &'static str) -> Self
+        where
+            T: TypeInfo + 'static,
+    {
+        Self {
+            ty: meta_type::<T>(),
+            name,
+        }
+    }
+}


### PR DESCRIPTION
Adds a `v13` feature which includes `scale-info` type information.

The `v13` metadata is still a work in progress and will likely require some further iteration as I work on the integration process with substrate.
