### PR TITLE
Complete v13 type definitions, support metadata decoding and serde

### DIFF
--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -25,5 +25,6 @@ v13 = ["scale-info"]
 std = [
 	"codec/std",
 	"scale-info/std",
+	"scale-info/serde",
 	"serde",
 ]

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -22,7 +22,11 @@
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
-		use serde::Serialize;
+		use serde::{
+			de::DeserializeOwned,
+			Deserialize,
+			Serialize,
+		};
 	} else {
 		extern crate alloc;
 		use alloc::vec::Vec;
@@ -37,12 +41,29 @@ pub mod v12;
 #[cfg(feature = "v13")]
 pub mod v13;
 
+cfg_if::cfg_if! {
+	if #[cfg(not(feature = "v13"))] {
+		/// Dummy trait in place of `scale_info::form::FormString`.
+		/// Since the `scale-info` crate is only imported for the `v13` feature.
+		pub trait FormString {}
+
+		impl FormString for &'static str {}
+		impl FormString for String {}
+	} else {
+		pub(crate) use scale_info::form::FormString;
+	}
+}
+
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub enum RuntimeMetadata {
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
+)]
+pub enum RuntimeMetadata<S: FormString = &'static str> {
 	/// Unused; enum filler.
 	V0(RuntimeMetadataDeprecated),
 	/// Version 1 for runtime metadata. No longer used.
@@ -69,13 +90,13 @@ pub enum RuntimeMetadata {
 	V11(RuntimeMetadataDeprecated),
 	/// Version 12 for runtime metadata
 	#[cfg(feature = "v12")]
-	V12(v12::RuntimeMetadataV12),
+	V12(v12::RuntimeMetadataV12<S>),
 	/// Version 12 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v12"))]
 	V12(OpaqueMetadata),
 	/// Version 13 for runtime metadata.
 	#[cfg(feature = "v13")]
-	V13(v13::RuntimeMetadataV13),
+	V13(v13::RuntimeMetadataV13<S>),
 	/// Version 13 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v13"))]
 	V13(OpaqueMetadata),
@@ -83,12 +104,12 @@ pub enum RuntimeMetadata {
 
 /// Stores the encoded `RuntimeMetadata` as raw bytes.
 #[derive(Encode, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
 pub struct OpaqueMetadata(pub Vec<u8>);
 
 /// Enum that should fail.
 #[derive(Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Serialize, Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 pub enum RuntimeMetadataDeprecated {}
 
 impl Encode for RuntimeMetadataDeprecated {

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -62,7 +62,7 @@ cfg_if::cfg_if! {
 #[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub enum RuntimeMetadata<S: FormString = &'static str> {
 	/// Unused; enum filler.
-	V0(RuntimeMetadataDeprecated),
+	V0(core::marker::PhantomData<S>),
 	/// Version 1 for runtime metadata. No longer used.
 	V1(RuntimeMetadataDeprecated),
 	/// Version 2 for runtime metadata. No longer used.

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -23,7 +23,6 @@ cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
 		use serde::{
-			de::DeserializeOwned,
 			Deserialize,
 			Serialize,
 		};
@@ -48,6 +47,7 @@ cfg_if::cfg_if! {
 		pub trait FormString {}
 
 		impl FormString for &'static str {}
+		#[cfg(feature = "std")]
 		impl FormString for String {}
 	} else {
 		pub(crate) use scale_info::form::FormString;
@@ -58,11 +58,8 @@ cfg_if::cfg_if! {
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub enum RuntimeMetadata<S: FormString = &'static str> {
 	/// Unused; enum filler.
 	V0(RuntimeMetadataDeprecated),

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -22,11 +22,7 @@ use codec::{Encode, Output};
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
-		use serde::{
-			de::DeserializeOwned,
-			Deserialize,
-			Serialize,
-		};
+		use serde::Serialize;
 
 		type StringBuf = String;
 	} else {
@@ -368,11 +364,8 @@ pub struct ExtrinsicMetadata {
 
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub struct RuntimeMetadataV12<S = ()> {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -35,8 +35,8 @@ cfg_if::cfg_if! {
 	}
 }
 
-use core::marker::PhantomData;
 use super::FormString;
+use core::marker::PhantomData;
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
@@ -350,7 +350,10 @@ pub struct StorageMetadata {
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(pub u32, pub super::RuntimeMetadata<S>);
+pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(
+	pub u32,
+	pub super::RuntimeMetadata<S>,
+);
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Eq, Encode, PartialEq)]
@@ -372,7 +375,7 @@ pub struct RuntimeMetadataV12<S = ()> {
 	/// Metadata of the extrinsic.
 	pub extrinsic: ExtrinsicMetadata,
 	/// Marker for dummy type parameter required by v13 but not used here.
-	pub marker: PhantomData<S>
+	pub marker: PhantomData<S>,
 }
 
 /// The latest version of the metadata.

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -22,7 +22,11 @@ use codec::{Encode, Output};
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
-		use serde::Serialize;
+		use serde::{
+			de::DeserializeOwned,
+			Deserialize,
+			Serialize,
+		};
 
 		type StringBuf = String;
 	} else {
@@ -34,6 +38,9 @@ cfg_if::cfg_if! {
 		type StringBuf = &'static str;
 	}
 }
+
+use core::marker::PhantomData;
+use super::FormString;
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
@@ -347,7 +354,7 @@ pub struct StorageMetadata {
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataPrefixed(pub u32, pub super::RuntimeMetadata);
+pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(pub u32, pub super::RuntimeMetadata<S>);
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Eq, Encode, PartialEq)]
@@ -361,12 +368,18 @@ pub struct ExtrinsicMetadata {
 
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataV12 {
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
+)]
+pub struct RuntimeMetadataV12<S = ()> {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 	/// Metadata of the extrinsic.
 	pub extrinsic: ExtrinsicMetadata,
+	/// Marker for dummy type parameter required by v13 but not used here.
+	pub marker: PhantomData<S>
 }
 
 /// The latest version of the metadata.

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -83,7 +83,7 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// Extrinsic version.
 	pub version: u8,
 	/// The signed extensions in the order they appear in the extrinsic.
-	pub signed_extensions: Vec<T::Type>,
+	pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
 }
 
 impl IntoPortable for ExtrinsicMetadata {
@@ -92,6 +92,28 @@ impl IntoPortable for ExtrinsicMetadata {
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
 			version: self.version,
+			signed_extensions: registry.map_into_portable(self.signed_extensions),
+		}
+	}
+}
+
+/// Metadata of an extrinsic's signed extension.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+pub struct SignedExtensionMetadata<T: Form = MetaForm> {
+	/// The unique .
+	pub identifier: T::String,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: T::Type,
+}
+
+impl IntoPortable for SignedExtensionMetadata {
+	type Output = SignedExtensionMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		SignedExtensionMetadata {
+			identifier: self.identifier.into_portable(registry),
 			signed_extensions: registry.register_types(self.signed_extensions),
 		}
 	}

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -80,6 +80,8 @@ impl RuntimeMetadataV13 {
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
+	/// The type of the extrinsic.
+	pub ty: T::Type,
 	/// Extrinsic version.
 	pub version: u8,
 	/// The signed extensions in the order they appear in the extrinsic.
@@ -91,6 +93,7 @@ impl IntoPortable for ExtrinsicMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
+			ty: self.ty.into_portable(registry),
 			version: self.version,
 			signed_extensions: registry.map_into_portable(self.signed_extensions),
 		}
@@ -102,7 +105,7 @@ impl IntoPortable for ExtrinsicMetadata {
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
-	/// The unique .
+	/// The unique signed extension identifier, which may be different from the type name.
 	pub identifier: T::String,
 	/// The signed extensions in the order they appear in the extrinsic.
 	pub signed_extensions: T::Type,

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -145,9 +145,9 @@ pub struct ModuleMetadata<T: Form = MetaForm> {
 	pub event: Option<Vec<EventMetadata<T>>>,
 	// pub constants: DFnA<ModuleConstantMetadata>,
 	pub errors: Vec<ErrorMetadata<T>>,
-	// /// Define the index of the module, this index will be used for the encoding of module event,
-	// /// call and origin variants.
-	// pub index: u8,
+	/// Define the index of the module, this index will be used for the encoding of module event,
+	/// call and origin variants.
+	pub index: u8,
 }
 
 impl IntoPortable for ModuleMetadata {
@@ -162,6 +162,7 @@ impl IntoPortable for ModuleMetadata {
 			calls: self.calls.map(|calls| registry.map_into_portable(calls)),
 			event: self.event.map(|event| registry.map_into_portable(event)),
 			errors: registry.map_into_portable(self.errors),
+			index: self.index,
 		}
 	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -39,7 +39,10 @@ pub type ByteGetter = Vec<u8>;
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
-pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(pub u32, pub super::RuntimeMetadata<S>);
+pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(
+	pub u32,
+	pub super::RuntimeMetadata<S>,
+);
 
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV13;
 
@@ -78,7 +81,10 @@ impl RuntimeMetadataV13 {
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// The type of the extrinsic.
 	pub ty: T::Type,
@@ -103,7 +109,10 @@ impl IntoPortable for ExtrinsicMetadata {
 /// Metadata of an extrinsic's signed extension.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
 	/// The unique signed extension identifier, which may be different from the type name.
 	pub identifier: T::String,
@@ -125,7 +134,10 @@ impl IntoPortable for SignedExtensionMetadata {
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct ModuleMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub storage: Option<Vec<StorageMetadata<T>>>,
@@ -157,7 +169,10 @@ impl IntoPortable for ModuleMetadata {
 /// All metadata of the storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct StorageMetadata<T: Form = MetaForm> {
 	/// The common prefix used by all storage entries.
 	pub prefix: T::String,
@@ -178,7 +193,10 @@ impl IntoPortable for StorageMetadata {
 /// All the metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub modifier: StorageEntryModifier,
@@ -225,7 +243,10 @@ pub enum StorageHasher {
 /// A storage entry type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub enum StorageEntryType<T: Form = MetaForm> {
 	Plain(T::String),
 	Map {
@@ -281,7 +302,10 @@ impl IntoPortable for StorageEntryType {
 /// All the metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct FunctionMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub arguments: Vec<FunctionArgumentMetadata<T>>,
@@ -303,7 +327,10 @@ impl IntoPortable for FunctionMetadata {
 /// All the metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub ty: T::Type,
@@ -325,7 +352,10 @@ impl IntoPortable for FunctionArgumentMetadata {
 /// All the metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct OuterEventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub events: Vec<ModuleEventMetadata<T>>,
@@ -345,7 +375,10 @@ impl IntoPortable for OuterEventMetadata {
 /// Metadata about a module event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct ModuleEventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub events: Vec<EventMetadata<T>>,
@@ -365,7 +398,10 @@ impl IntoPortable for ModuleEventMetadata {
 /// All the metadata about an event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct EventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub arguments: Vec<TypeSpec<T>>,
@@ -387,7 +423,10 @@ impl IntoPortable for EventMetadata {
 /// All the metadata about a module error.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct ErrorMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub documentation: Vec<T::String>,
@@ -423,7 +462,10 @@ impl IntoPortable for ErrorMetadata {
 /// simply be a type alias to `fn(i32, i32) -> Ordering`.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
+#[cfg_attr(
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
 pub struct TypeSpec<T: Form = MetaForm> {
 	/// The actual type.
 	pub ty: T::Type,

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -17,12 +17,8 @@
 
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
-		use codec::{Decode, Error, Input};
-		use serde::{
-			de::DeserializeOwned,
-			Deserialize,
-			Serialize,
-		};
+		use codec::Decode;
+		use serde::Serialize;
 	}
 }
 
@@ -41,11 +37,8 @@ pub type ByteGetter = Vec<u8>;
 
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(pub u32, pub super::RuntimeMetadata<S>);
 
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV13;
@@ -59,11 +52,8 @@ impl From<RuntimeMetadataLastVersion> for RuntimeMetadataPrefixed {
 /// The metadata of a runtime.
 // todo: [AJ] add back clone derive if required (requires PortableRegistry to implement clone)
 #[derive(PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "S: Serialize", deserialize = "S: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub struct RuntimeMetadataV13<S: FormString = &'static str> {
 	pub types: PortableRegistry<S>,
 	/// Metadata of all the modules.
@@ -87,11 +77,8 @@ impl RuntimeMetadataV13 {
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// Extrinsic version.
 	pub version: u8,
@@ -112,11 +99,8 @@ impl IntoPortable for ExtrinsicMetadata {
 
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct ModuleMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub storage: Option<Vec<StorageMetadata<T>>>,
@@ -147,11 +131,8 @@ impl IntoPortable for ModuleMetadata {
 
 /// All metadata of the storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct StorageMetadata<T: Form = MetaForm> {
 	/// The common prefix used by all storage entries.
 	pub prefix: T::String,
@@ -171,11 +152,8 @@ impl IntoPortable for StorageMetadata {
 
 /// All the metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub modifier: StorageEntryModifier,
@@ -200,7 +178,7 @@ impl IntoPortable for StorageEntryMetadata {
 
 /// A storage entry modifier.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {
 	Optional,
 	Default,
@@ -208,7 +186,7 @@ pub enum StorageEntryModifier {
 
 /// Hasher used by storage maps
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageHasher {
 	Blake2_128,
 	Blake2_256,
@@ -221,11 +199,8 @@ pub enum StorageHasher {
 
 /// A storage entry type.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub enum StorageEntryType<T: Form = MetaForm> {
 	Plain(T::String),
 	Map {
@@ -280,11 +255,8 @@ impl IntoPortable for StorageEntryType {
 
 /// All the metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct FunctionMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub arguments: Vec<FunctionArgumentMetadata<T>>,
@@ -305,11 +277,8 @@ impl IntoPortable for FunctionMetadata {
 
 /// All the metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub ty: T::Type,
@@ -330,11 +299,8 @@ impl IntoPortable for FunctionArgumentMetadata {
 
 /// All the metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct OuterEventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub events: Vec<ModuleEventMetadata<T>>,
@@ -353,11 +319,8 @@ impl IntoPortable for OuterEventMetadata {
 
 /// Metadata about a module event.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct ModuleEventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub events: Vec<EventMetadata<T>>,
@@ -376,11 +339,8 @@ impl IntoPortable for ModuleEventMetadata {
 
 /// All the metadata about an event.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct EventMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub arguments: Vec<TypeSpec<T>>,
@@ -401,11 +361,8 @@ impl IntoPortable for EventMetadata {
 
 /// All the metadata about a module error.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct ErrorMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub documentation: Vec<T::String>,
@@ -440,11 +397,8 @@ impl IntoPortable for ErrorMetadata {
 /// the return type is simply `bool`. Note that `Predicate` could
 /// simply be a type alias to `fn(i32, i32) -> Ordering`.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T: Serialize", deserialize = "T: DeserializeOwned"))
-)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize, T::String: Serialize")))]
 pub struct TypeSpec<T: Form = MetaForm> {
 	/// The actual type.
 	pub ty: T::Type,

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -93,7 +93,7 @@ impl IntoPortable for ExtrinsicMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
-			ty: self.ty.into_portable(registry),
+			ty: registry.register_type(&self.ty),
 			version: self.version,
 			signed_extensions: registry.map_into_portable(self.signed_extensions),
 		}
@@ -108,7 +108,7 @@ pub struct SignedExtensionMetadata<T: Form = MetaForm> {
 	/// The unique signed extension identifier, which may be different from the type name.
 	pub identifier: T::String,
 	/// The signed extensions in the order they appear in the extrinsic.
-	pub signed_extensions: T::Type,
+	pub ty: T::Type,
 }
 
 impl IntoPortable for SignedExtensionMetadata {
@@ -117,7 +117,7 @@ impl IntoPortable for SignedExtensionMetadata {
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		SignedExtensionMetadata {
 			identifier: self.identifier.into_portable(registry),
-			signed_extensions: registry.register_types(self.signed_extensions),
+			ty: registry.register_type(&self.ty),
 		}
 	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -161,7 +161,9 @@ impl IntoPortable for ModuleMetadata {
 				.map(|storage| registry.map_into_portable(storage)),
 			calls: self.calls.map(|calls| registry.map_into_portable(calls)),
 			event: self.event.map(|event| registry.map_into_portable(event)),
-			constants: self.constants.map(|constant| registry.map_into_portable(constant)),
+			constants: self
+				.constants
+				.map(|constant| registry.map_into_portable(constant)),
 			errors: registry.map_into_portable(self.errors),
 			index: self.index,
 		}


### PR DESCRIPTION
More features for substrate compatibility and for use of the resulting encoded metadata in https://github.com/ascjones/chameleon.

- Support SCALE decoding of v13 metadata
- Support serde serialization of v13 metadata
- Add definintion for extrinsics and their signed extensions
