### PR TITLE
Extract duplicated RuntimeMetadataPrefixed struct to crate level

### DIFF
--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -54,6 +54,18 @@ cfg_if::cfg_if! {
 	}
 }
 
+/// Metadata prefixed by a u32 for reserved usage
+#[derive(Eq, Encode, PartialEq)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
+pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(pub u32, pub RuntimeMetadata<S>);
+
+impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
+	fn into(self) -> Vec<u8> {
+		self.encode()
+	}
+}
+
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -35,7 +35,6 @@ cfg_if::cfg_if! {
 	}
 }
 
-use super::FormString;
 use core::marker::PhantomData;
 
 /// Current prefix of metadata
@@ -347,14 +346,6 @@ pub struct StorageMetadata {
 	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
 }
 
-/// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(
-	pub u32,
-	pub super::RuntimeMetadata<S>,
-);
-
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
@@ -398,9 +389,3 @@ pub struct ModuleMetadata {
 
 type ODFnA<T> = Option<DFnA<T>>;
 type DFnA<T> = DecodeDifferent<FnEncode<&'static [T]>, Vec<T>>;
-
-impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
-	fn into(self) -> Vec<u8> {
-		self.encode()
-	}
-}

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -22,6 +22,7 @@ cfg_if::cfg_if! {
 	}
 }
 
+use super::RuntimeMetadataPrefixed;
 use codec::Encode;
 use scale_info::prelude::vec::Vec;
 use scale_info::{
@@ -35,18 +36,9 @@ pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 /// Type alias placeholder for `ByteGetter` equivalent. todo: [AJ] figure out what to do here
 pub type ByteGetter = Vec<u8>;
 
-/// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
-pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(
-	pub u32,
-	pub super::RuntimeMetadata<S>,
-);
-
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV13;
 
-impl From<RuntimeMetadataLastVersion> for RuntimeMetadataPrefixed {
+impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 	fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
 		RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V13(metadata))
 	}


### PR DESCRIPTION
Currently this type is duplicated in both `v12` and `v13`, when it should be version agnostic because it contains the `RuntimeMetadataPrefixed` enum. 

I've left the `META_RESERVED` constant in both versions, even though it is the same, in case it can change in the future.