### PR TITLE
Update to latest scale-info & codec, remove string parameterization

### DIFF
--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 cfg-if = "1.0.0"
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, optional = true, features = ["derive"] }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-substrate", default-features = false, optional = true, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 cfg-if = "1.0.0"
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-substrate", default-features = false, optional = true, features = ["derive"] }
+scale-info = { version = "0.6.0", default-features = false, optional = true, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 cfg-if = "1.0.0"
-scale-info = { git = "https://github.com/paritytech/scale-info", default-features = false, optional = true, features = ["derive"] }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, optional = true, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]
@@ -26,5 +26,6 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"scale-info/serde",
+	"scale-info/decode",
 	"serde",
 ]

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -43,7 +43,6 @@ pub mod v13;
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
 
 impl Into<Vec<u8>> for RuntimeMetadataPrefixed {

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -40,25 +40,11 @@ pub mod v12;
 #[cfg(feature = "v13")]
 pub mod v13;
 
-cfg_if::cfg_if! {
-	if #[cfg(not(feature = "v13"))] {
-		/// Dummy trait in place of `scale_info::form::FormString`.
-		/// Since the `scale-info` crate is only imported for the `v13` feature.
-		pub trait FormString {}
-
-		impl FormString for &'static str {}
-		#[cfg(feature = "std")]
-		impl FormString for String {}
-	} else {
-		pub(crate) use scale_info::form::FormString;
-	}
-}
-
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
-pub struct RuntimeMetadataPrefixed<S: FormString = &'static str>(pub u32, pub RuntimeMetadata<S>);
+pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
 
 impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
 	fn into(self) -> Vec<u8> {
@@ -72,9 +58,9 @@ impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
-pub enum RuntimeMetadata<S: FormString = &'static str> {
+pub enum RuntimeMetadata {
 	/// Unused; enum filler.
-	V0(core::marker::PhantomData<S>),
+	V0(RuntimeMetadataDeprecated),
 	/// Version 1 for runtime metadata. No longer used.
 	V1(RuntimeMetadataDeprecated),
 	/// Version 2 for runtime metadata. No longer used.
@@ -99,13 +85,13 @@ pub enum RuntimeMetadata<S: FormString = &'static str> {
 	V11(RuntimeMetadataDeprecated),
 	/// Version 12 for runtime metadata
 	#[cfg(feature = "v12")]
-	V12(v12::RuntimeMetadataV12<S>),
+	V12(v12::RuntimeMetadataV12),
 	/// Version 12 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v12"))]
 	V12(OpaqueMetadata),
 	/// Version 13 for runtime metadata.
 	#[cfg(feature = "v13")]
-	V13(v13::RuntimeMetadataV13<S>),
+	V13(v13::RuntimeMetadataV13),
 	/// Version 13 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v13"))]
 	V13(OpaqueMetadata),
@@ -122,7 +108,7 @@ pub struct OpaqueMetadata(pub Vec<u8>);
 pub enum RuntimeMetadataDeprecated {}
 
 impl Encode for RuntimeMetadataDeprecated {
-	fn encode_to<W: Output>(&self, _dest: &mut W) {}
+	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {}
 }
 
 impl codec::EncodeLike for RuntimeMetadataDeprecated {}

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -57,7 +57,6 @@ impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
 /// the enum nature of `RuntimeMetadata`.
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub enum RuntimeMetadata {
 	/// Unused; enum filler.
 	V0(RuntimeMetadataDeprecated),

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -359,7 +359,6 @@ pub struct ExtrinsicMetadata {
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub struct RuntimeMetadataV12<S = ()> {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -59,7 +59,7 @@ where
 	B: Encode + 'static,
 	O: Encode + 'static,
 {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self {
 			DecodeDifferent::Encode(b) => b.encode_to(dest),
 			DecodeDifferent::Decoded(o) => o.encode_to(dest),
@@ -160,7 +160,7 @@ where
 	E: Encode + 'static;
 
 impl<E: Encode> Encode for FnEncode<E> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		self.0().encode_to(dest);
 	}
 }
@@ -262,7 +262,7 @@ pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
 pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
 
 impl Encode for DefaultByteGetter {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		self.0.default_byte().encode_to(dest)
 	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -26,7 +26,7 @@ use super::RuntimeMetadataPrefixed;
 use codec::Encode;
 use scale_info::prelude::vec::Vec;
 use scale_info::{
-	form::{Form, FormString, MetaForm, PortableForm},
+	form::{Form, MetaForm, PortableForm},
 	meta_type, IntoPortable, PortableRegistry, Registry, TypeInfo,
 };
 
@@ -49,12 +49,12 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 #[derive(PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
-pub struct RuntimeMetadataV13<S: FormString = &'static str> {
-	pub types: PortableRegistry<S>,
+pub struct RuntimeMetadataV13 {
+	pub types: PortableRegistry,
 	/// Metadata of all the modules.
-	pub modules: Vec<ModuleMetadata<PortableForm<S>>>,
+	pub modules: Vec<ModuleMetadata<PortableForm>>,
 	/// Metadata of the extrinsic.
-	pub extrinsic: ExtrinsicMetadata<PortableForm<S>>,
+	pub extrinsic: ExtrinsicMetadata<PortableForm>,
 }
 
 impl RuntimeMetadataV13 {

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -48,7 +48,6 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 // todo: [AJ] add back clone derive if required (requires PortableRegistry to implement clone)
 #[derive(PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "S: Serialize")))]
 pub struct RuntimeMetadataV13 {
 	pub types: PortableRegistry,
 	/// Metadata of all the modules.


### PR DESCRIPTION
Convert to use new `decode` feature in `scale-info` for environments where decoding is enabled, which removes the hacky string parameterization. See https://github.com/paritytech/scale-info/pull/59

## todo
- [x] Once https://github.com/paritytech/scale-info/pull/59 is merged and released, update to new release here.