### PR TITLE
Remove `FunctionArgumentMetadata::is_compact` flag

### DIFF
--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -327,7 +327,6 @@ impl IntoPortable for FunctionMetadata {
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub ty: T::Type,
-	pub is_compact: bool,
 }
 
 impl IntoPortable for FunctionArgumentMetadata {
@@ -337,7 +336,6 @@ impl IntoPortable for FunctionArgumentMetadata {
 		FunctionArgumentMetadata {
 			name: self.name.into_portable(registry),
 			ty: registry.register_type(&self.ty),
-			is_compact: self.is_compact,
 		}
 	}
 }


### PR DESCRIPTION
It's made redundant by the type information provided by `scale-info`