### PR TITLE
Refactor v13 metadata types

### DIFF
--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -135,7 +135,7 @@ pub struct PalletMetadata<T: Form = MetaForm> {
 	pub calls: Option<PalletCallMetadata<T>>,
 	pub event: Option<PalletEventMetadata<T>>,
 	pub constants: Vec<PalletConstantMetadata<T>>,
-	pub errors: PalletErrorMetadata<T>,
+	pub error: Option<PalletErrorMetadata<T>>,
 	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
 	/// call and origin variants.
 	pub index: u8,
@@ -151,7 +151,7 @@ impl IntoPortable for PalletMetadata {
 			calls: self.calls.map(|calls| calls.into_portable(registry)),
 			event: self.event.map(|event| event.into_portable(registry)),
 			constants: registry.map_into_portable(self.constants),
-			errors: self.errors.into_portable(registry),
+			error: self.error.into_portable(registry),
 			index: self.index,
 		}
 	}

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -135,7 +135,7 @@ pub struct PalletMetadata<T: Form = MetaForm> {
 	pub calls: Option<PalletCallMetadata<T>>,
 	pub event: Option<PalletEventMetadata<T>>,
 	pub constants: Vec<PalletConstantMetadata<T>>,
-	pub errors: ErrorMetadata<T>,
+	pub errors: PalletErrorMetadata<T>,
 	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
 	/// call and origin variants.
 	pub index: u8,
@@ -406,16 +406,16 @@ impl IntoPortable for PalletConstantMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize")))]
-pub struct ErrorMetadata<T: Form = MetaForm> {
+pub struct PalletErrorMetadata<T: Form = MetaForm> {
 	/// The error type information.
 	pub ty: T::Type,
 }
 
-impl IntoPortable for ErrorMetadata {
-	type Output = ErrorMetadata<PortableForm>;
+impl IntoPortable for PalletErrorMetadata {
+	type Output = PalletErrorMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		ErrorMetadata {
+		PalletErrorMetadata {
 			ty: registry.register_type(&self.ty),
 		}
 	}

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -131,7 +131,7 @@ impl IntoPortable for SignedExtensionMetadata {
 )]
 pub struct PalletMetadata<T: Form = MetaForm> {
 	pub name: T::String,
-	pub storage: Option<StorageMetadata<T>>,
+	pub storage: Option<PalletStorageMetadata<T>>,
 	pub calls: Option<PalletCallMetadata<T>>,
 	pub event: Option<PalletEventMetadata<T>>,
 	pub constants: Vec<PalletConstantMetadata<T>>,
@@ -157,24 +157,24 @@ impl IntoPortable for PalletMetadata {
 	}
 }
 
-/// All metadata of the storage.module
+/// All metadata of the pallet's storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
 	feature = "std",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct StorageMetadata<T: Form = MetaForm> {
+pub struct PalletStorageMetadata<T: Form = MetaForm> {
 	/// The common prefix used by all storage entries.
 	pub prefix: T::String,
 	pub entries: Vec<StorageEntryMetadata<T>>,
 }
 
-impl IntoPortable for StorageMetadata {
-	type Output = StorageMetadata<PortableForm>;
+impl IntoPortable for PalletStorageMetadata {
+	type Output = PalletStorageMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		StorageMetadata {
+		PalletStorageMetadata {
 			prefix: self.prefix.into_portable(registry),
 			entries: registry.map_into_portable(self.entries),
 		}

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -407,13 +407,10 @@ impl IntoPortable for PalletConstantMetadata {
 /// Metadata about a pallet error.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T::Type: Serialize"))
-)]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize")))]
 pub struct ErrorMetadata<T: Form = MetaForm> {
 	/// The error type information.
-	pub ty: T::Type
+	pub ty: T::Type,
 }
 
 impl IntoPortable for ErrorMetadata {
@@ -421,7 +418,7 @@ impl IntoPortable for ErrorMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ErrorMetadata {
-			ty: registry.register_type(&self.ty)
+			ty: registry.register_type(&self.ty),
 		}
 	}
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -50,20 +50,20 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct RuntimeMetadataV13 {
 	pub types: PortableRegistry,
-	/// Metadata of all the modules.
-	pub modules: Vec<ModuleMetadata<PortableForm>>,
+	/// Metadata of all the pallets.
+	pub pallets: Vec<PalletMetadata<PortableForm>>,
 	/// Metadata of the extrinsic.
 	pub extrinsic: ExtrinsicMetadata<PortableForm>,
 }
 
 impl RuntimeMetadataV13 {
-	pub fn new(modules: Vec<ModuleMetadata>, extrinsic: ExtrinsicMetadata) -> Self {
+	pub fn new(pallets: Vec<PalletMetadata>, extrinsic: ExtrinsicMetadata) -> Self {
 		let mut registry = Registry::new();
-		let modules = registry.map_into_portable(modules);
+		let pallets = registry.map_into_portable(pallets);
 		let extrinsic = extrinsic.into_portable(&mut registry);
 		Self {
 			types: registry.into(),
-			modules,
+			pallets,
 			extrinsic,
 		}
 	}
@@ -122,30 +122,30 @@ impl IntoPortable for SignedExtensionMetadata {
 	}
 }
 
-/// All metadata about an runtime module.
+/// All metadata about an runtime pallet.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
 	feature = "std",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct ModuleMetadata<T: Form = MetaForm> {
+pub struct PalletMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub storage: Option<StorageMetadata<T>>,
-	pub calls: Option<ModuleCallsMetadata<T>>,
-	pub event: Option<ModuleEventMetadata<T>>,
-	pub constants: Option<Vec<ModuleConstantMetadata<T>>>,
+	pub calls: Option<PalletCallMetadata<T>>,
+	pub event: Option<PalletEventMetadata<T>>,
+	pub constants: Option<Vec<PalletConstantMetadata<T>>>,
 	pub errors: ErrorMetadata<T>,
-	/// Define the index of the module, this index will be used for the encoding of module event,
+	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
 	/// call and origin variants.
 	pub index: u8,
 }
 
-impl IntoPortable for ModuleMetadata {
-	type Output = ModuleMetadata<PortableForm>;
+impl IntoPortable for PalletMetadata {
+	type Output = PalletMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		ModuleMetadata {
+		PalletMetadata {
 			name: self.name.into_portable(registry),
 			storage: self.storage.map(|storage| storage.into_portable(registry)),
 			calls: self.calls.map(|calls| calls.into_portable(registry)),
@@ -159,7 +159,7 @@ impl IntoPortable for ModuleMetadata {
 	}
 }
 
-/// All metadata of the storage.
+/// All metadata of the storage.module
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
@@ -292,24 +292,24 @@ impl IntoPortable for StorageEntryType {
 	}
 }
 
-/// Metadata for all
+/// Metadata for all calls in a pallet
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
 	feature = "std",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct ModuleCallsMetadata<T: Form = MetaForm> {
-	/// The corresponding enum type for the module call.
+pub struct PalletCallMetadata<T: Form = MetaForm> {
+	/// The corresponding enum type for the pallet call.
 	pub ty: T::Type,
 	pub calls: Vec<FunctionMetadata<T>>,
 }
 
-impl IntoPortable for ModuleCallsMetadata {
-	type Output = ModuleCallsMetadata<PortableForm>;
+impl IntoPortable for PalletCallMetadata {
+	type Output = PalletCallMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		ModuleCallsMetadata {
+		PalletCallMetadata {
 			ty: registry.register_type(&self.ty),
 			calls: registry.map_into_portable(self.calls),
 		}
@@ -364,46 +364,46 @@ impl IntoPortable for FunctionArgumentMetadata {
 	}
 }
 
-/// Metadata about a module event.
+/// Metadata about the pallet event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
 	feature = "std",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct ModuleEventMetadata<T: Form = MetaForm> {
+pub struct PalletEventMetadata<T: Form = MetaForm> {
 	pub ty: T::Type,
 }
 
-impl IntoPortable for ModuleEventMetadata {
-	type Output = ModuleEventMetadata<PortableForm>;
+impl IntoPortable for PalletEventMetadata {
+	type Output = PalletEventMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		ModuleEventMetadata {
+		PalletEventMetadata {
 			ty: registry.register_type(&self.ty),
 		}
 	}
 }
 
-/// All the metadata about one module constant.
+/// All the metadata about one pallet constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
 	feature = "std",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct ModuleConstantMetadata<T: Form = MetaForm> {
+pub struct PalletConstantMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub ty: T::Type,
 	pub value: ByteGetter,
 	pub documentation: Vec<T::String>,
 }
 
-impl IntoPortable for ModuleConstantMetadata {
-	type Output = ModuleConstantMetadata<PortableForm>;
+impl IntoPortable for PalletConstantMetadata {
+	type Output = PalletConstantMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		ModuleConstantMetadata {
+		PalletConstantMetadata {
 			name: self.name.into_portable(registry),
 			ty: registry.register_type(&self.ty),
 			value: self.value,
@@ -412,7 +412,7 @@ impl IntoPortable for ModuleConstantMetadata {
 	}
 }
 
-/// Metadata about a module error.
+/// Metadata about a pallet error.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -344,10 +344,6 @@ impl IntoPortable for FunctionMetadata {
 /// All the metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub ty: T::Type,
@@ -367,10 +363,6 @@ impl IntoPortable for FunctionArgumentMetadata {
 /// Metadata about the pallet event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(
-	feature = "std",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
 	pub ty: T::Type,
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -151,7 +151,7 @@ impl IntoPortable for PalletMetadata {
 			calls: self.calls.map(|calls| calls.into_portable(registry)),
 			event: self.event.map(|event| event.into_portable(registry)),
 			constants: registry.map_into_portable(self.constants),
-			error: self.error.into_portable(registry),
+			error: self.error.map(|error| error.into_portable(registry)),
 			index: self.index,
 		}
 	}


### PR DESCRIPTION
Replace custom definitions for errors and event metadata with scale-info type information for the pallet `Event` and `Error` types (depends on https://github.com/paritytech/scale-info/pull/87 which adds documentation to the `scale-info` derive). 

As @thiolliere [pointed out](https://github.com/paritytech/substrate/pull/8615#discussion_r613292720), metadata for events and errors (which are expanded to simple enums) can be captured already by the `scale_info` derives. 

Call definitions could also just use the `scale-info` derives on the `Call` enum also, but we will keep the custom types in case we need to add additional metadata, see the [comment below](https://github.com/paritytech/frame-metadata/pull/11#issuecomment-827556297).

Also: 

- Renames types/comments with module -> pallet
- Adds wrapper types for calls and events metadata
