### PR TITLE
Copy v13 metadata from substrate, move new scale-info version to v14

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,10 +110,16 @@ jobs:
           command:                 check
           toolchain:               stable
           args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v13
+      - name:                      Checking v14
+        uses:                      actions-rs/cargo@master
+        with:
+          command:                 check
+          toolchain:               stable
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v14
       - name:                      Checking all versions
         uses:                      actions-rs/cargo@master
         with:
           command:                 check
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12,v13
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12,v13,v14
 

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "12.0.0"
+version = "14.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -19,9 +19,10 @@ scale-info = { version = "0.6.0", default-features = false, optional = true, fea
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]
-default = ["std", "v12"]
+default = ["std", "v14"]
 v12 = []
-v13 = ["scale-info"]
+v13 = []
+v14 = ["scale-info"]
 std = [
 	"codec/std",
 	"scale-info/std",

--- a/frame-metadata/src/decode_different.rs
+++ b/frame-metadata/src/decode_different.rs
@@ -20,8 +20,6 @@ use codec::{Encode, Output};
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
-		use serde::Serialize;
-
 		pub type StringBuf = String;
 	} else {
 		extern crate alloc;
@@ -128,23 +126,6 @@ where
 pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
 
 pub type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
-
-/// Metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub struct FunctionMetadata {
-	pub name: DecodeDifferentStr,
-	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// Metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub struct FunctionArgumentMetadata {
-	pub name: DecodeDifferentStr,
-	pub ty: DecodeDifferentStr,
-}
 
 /// Newtype wrapper for support encoding functions (actual the result of the function).
 #[derive(Clone, Eq)]

--- a/frame-metadata/src/decode_different.rs
+++ b/frame-metadata/src/decode_different.rs
@@ -1,0 +1,183 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Encode, Output};
+
+cfg_if::cfg_if! {
+	if #[cfg(feature = "std")] {
+		use codec::{Decode, Error, Input};
+		use serde::Serialize;
+
+		pub type StringBuf = String;
+	} else {
+		extern crate alloc;
+		use alloc::vec::Vec;
+
+		/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
+		/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
+		pub type StringBuf = &'static str;
+	}
+}
+
+/// A type that decodes to a different type than it encodes.
+/// The user needs to make sure that both types use the same encoding.
+///
+/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
+#[derive(Clone)]
+pub enum DecodeDifferent<B, O>
+where
+	B: 'static,
+	O: 'static,
+{
+	Encode(B),
+	Decoded(O),
+}
+
+impl<B, O> Encode for DecodeDifferent<B, O>
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
+{
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
+		match self {
+			DecodeDifferent::Encode(b) => b.encode_to(dest),
+			DecodeDifferent::Decoded(o) => o.encode_to(dest),
+		}
+	}
+}
+
+impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
+{
+}
+
+#[cfg(feature = "std")]
+impl<B, O> Decode for DecodeDifferent<B, O>
+where
+	B: 'static,
+	O: Decode + 'static,
+{
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
+	}
+}
+
+impl<B, O> PartialEq for DecodeDifferent<B, O>
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
+{
+	fn eq(&self, other: &Self) -> bool {
+		self.encode() == other.encode()
+	}
+}
+
+impl<B, O> Eq for DecodeDifferent<B, O>
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
+{
+}
+
+impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
+where
+	B: core::fmt::Debug + Eq + 'static,
+	O: core::fmt::Debug + Eq + 'static,
+{
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		match self {
+			DecodeDifferent::Encode(b) => b.fmt(f),
+			DecodeDifferent::Decoded(o) => o.fmt(f),
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl<B, O> serde::Serialize for DecodeDifferent<B, O>
+where
+	B: serde::Serialize + 'static,
+	O: serde::Serialize + 'static,
+{
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		match self {
+			DecodeDifferent::Encode(b) => b.serialize(serializer),
+			DecodeDifferent::Decoded(o) => o.serialize(serializer),
+		}
+	}
+}
+
+pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
+
+pub type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
+
+/// All the metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
+pub struct FunctionMetadata {
+	pub name: DecodeDifferentStr,
+	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// All the metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
+pub struct FunctionArgumentMetadata {
+	pub name: DecodeDifferentStr,
+	pub ty: DecodeDifferentStr,
+}
+
+/// Newtype wrapper for support encoding functions (actual the result of the function).
+#[derive(Clone, Eq)]
+pub struct FnEncode<E>(pub fn() -> E)
+where
+	E: Encode + 'static;
+
+impl<E: Encode> Encode for FnEncode<E> {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
+		self.0().encode_to(dest);
+	}
+}
+
+impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
+
+impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
+	fn eq(&self, other: &Self) -> bool {
+		self.0().eq(&other.0())
+	}
+}
+
+impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.0().fmt(f)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.0().serialize(serializer)
+	}
+}

--- a/frame-metadata/src/decode_different.rs
+++ b/frame-metadata/src/decode_different.rs
@@ -129,7 +129,7 @@ pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
 
 pub type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
 
-/// All the metadata about a function.
+/// Metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
@@ -138,7 +138,7 @@ pub struct FunctionMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about a function argument.
+/// Metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -40,6 +40,9 @@ pub mod v12;
 #[cfg(feature = "v13")]
 pub mod v13;
 
+#[cfg(feature = "v14")]
+pub mod v14;
+
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
@@ -93,6 +96,12 @@ pub enum RuntimeMetadata {
 	/// Version 13 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v13"))]
 	V13(OpaqueMetadata),
+	/// Version 14 for runtime metadata.
+	#[cfg(feature = "v14")]
+	V14(v14::RuntimeMetadataV14),
+	/// Version 14 for runtime metadata, as raw encoded bytes.
+	#[cfg(not(feature = "v14"))]
+	V14(OpaqueMetadata),
 }
 
 /// Stores the encoded `RuntimeMetadata` as raw bytes.

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -34,6 +34,9 @@ cfg_if::cfg_if! {
 
 use codec::{Encode, Output};
 
+#[cfg(any(feature = "v12", feature = "v13"))]
+pub mod decode_different;
+
 #[cfg(feature = "v12")]
 pub mod v12;
 

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -39,7 +39,7 @@ use core::marker::PhantomData;
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
-/// All the metadata about a function.
+/// Metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct FunctionMetadata {
@@ -48,7 +48,7 @@ pub struct FunctionMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about a function argument.
+/// Metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct FunctionArgumentMetadata {
@@ -56,7 +56,7 @@ pub struct FunctionArgumentMetadata {
 	pub ty: DecodeDifferentStr,
 }
 
-/// All the metadata about an outer event.
+/// Metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct OuterEventMetadata {
@@ -67,7 +67,7 @@ pub struct OuterEventMetadata {
 	>,
 }
 
-/// All the metadata about an event.
+/// Metadata about an event.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct EventMetadata {
@@ -76,7 +76,7 @@ pub struct EventMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about one storage entry.
+/// Metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct StorageEntryMetadata {
@@ -87,7 +87,7 @@ pub struct StorageEntryMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about one module constant.
+/// Metadata about one module constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct ModuleConstantMetadata {
@@ -97,7 +97,7 @@ pub struct ModuleConstantMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about a module error.
+/// Metadata about a module error.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct ErrorMetadata {
@@ -105,7 +105,7 @@ pub struct ErrorMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about errors in a module.
+/// Metadata about errors in a module.
 pub trait ModuleErrorMetadata {
 	fn metadata() -> &'static [ErrorMetadata];
 }

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -15,13 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Decodable variant of the RuntimeMetadata.
-
+use crate::decode_different::*;
 use codec::{Encode, Output};
 
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
-		use codec::{Decode, Error, Input};
+		use codec::Decode;
 		use serde::Serialize;
 
 		type StringBuf = String;
@@ -40,102 +39,6 @@ use core::marker::PhantomData;
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
-/// A type that decodes to a different type than it encodes.
-/// The user needs to make sure that both types use the same encoding.
-///
-/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
-#[derive(Clone)]
-pub enum DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: 'static,
-{
-	Encode(B),
-	Decoded(O),
-}
-
-impl<B, O> Encode for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
-		match self {
-			DecodeDifferent::Encode(b) => b.encode_to(dest),
-			DecodeDifferent::Decoded(o) => o.encode_to(dest),
-		}
-	}
-}
-
-impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-}
-
-#[cfg(feature = "std")]
-impl<B, O> Decode for DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: Decode + 'static,
-{
-	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
-	}
-}
-
-impl<B, O> PartialEq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.encode() == other.encode()
-	}
-}
-
-impl<B, O> Eq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-}
-
-impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
-where
-	B: core::fmt::Debug + Eq + 'static,
-	O: core::fmt::Debug + Eq + 'static,
-{
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		match self {
-			DecodeDifferent::Encode(b) => b.fmt(f),
-			DecodeDifferent::Decoded(o) => o.fmt(f),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl<B, O> serde::Serialize for DecodeDifferent<B, O>
-where
-	B: serde::Serialize + 'static,
-	O: serde::Serialize + 'static,
-{
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			DecodeDifferent::Encode(b) => b.serialize(serializer),
-			DecodeDifferent::Decoded(o) => o.serialize(serializer),
-		}
-	}
-}
-
-pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
-
-type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
-
 /// All the metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
@@ -151,42 +54,6 @@ pub struct FunctionMetadata {
 pub struct FunctionArgumentMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
-}
-
-/// Newtype wrapper for support encoding functions (actual the result of the function).
-#[derive(Clone, Eq)]
-pub struct FnEncode<E>(pub fn() -> E)
-where
-	E: Encode + 'static;
-
-impl<E: Encode> Encode for FnEncode<E> {
-	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
-		self.0().encode_to(dest);
-	}
-}
-
-impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
-
-impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
-	fn eq(&self, other: &Self) -> bool {
-		self.0().eq(&other.0())
-	}
-}
-
-impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.0().fmt(f)
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		self.0().serialize(serializer)
-	}
 }
 
 /// All the metadata about an outer event.

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -34,8 +34,6 @@ cfg_if::cfg_if! {
 	}
 }
 
-use core::marker::PhantomData;
-
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
@@ -226,17 +224,12 @@ pub struct ExtrinsicMetadata {
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-pub struct RuntimeMetadataV12<S = ()> {
+pub struct RuntimeMetadataV12 {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 	/// Metadata of the extrinsic.
 	pub extrinsic: ExtrinsicMetadata,
-	/// Marker for dummy type parameter required by v13 but not used here.
-	pub marker: PhantomData<S>,
 }
-
-/// The latest version of the metadata.
-pub type RuntimeMetadataLastVersion = RuntimeMetadataV12;
 
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode)]

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -31,6 +31,23 @@ cfg_if::cfg_if! {
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
+/// Metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionMetadata {
+	pub name: DecodeDifferentStr,
+	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
+}
+
+/// Metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionArgumentMetadata {
+	pub name: DecodeDifferentStr,
+	pub ty: DecodeDifferentStr,
+}
+
 /// Metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -43,12 +43,20 @@ pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 ///
 /// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
 #[derive(Clone)]
-pub enum DecodeDifferent<B, O> where B: 'static, O: 'static {
+pub enum DecodeDifferent<B, O>
+where
+	B: 'static,
+	O: 'static,
+{
 	Encode(B),
 	Decoded(O),
 }
 
-impl<B, O> Encode for DecodeDifferent<B, O> where B: Encode + 'static, O: Encode + 'static {
+impl<B, O> Encode for DecodeDifferent<B, O>
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
+{
 	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self {
 			DecodeDifferent::Encode(b) => b.encode_to(dest),
@@ -57,21 +65,28 @@ impl<B, O> Encode for DecodeDifferent<B, O> where B: Encode + 'static, O: Encode
 	}
 }
 
-impl<B, O> codec::EncodeLike for DecodeDifferent<B, O> where B: Encode + 'static, O: Encode + 'static {}
+impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
+where
+	B: Encode + 'static,
+	O: Encode + 'static,
+{
+}
 
 #[cfg(feature = "std")]
-impl<B, O> Decode for DecodeDifferent<B, O> where B: 'static, O: Decode + 'static {
+impl<B, O> Decode for DecodeDifferent<B, O>
+where
+	B: 'static,
+	O: Decode + 'static,
+{
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		<O>::decode(input).map(|val| {
-			DecodeDifferent::Decoded(val)
-		})
+		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
 	}
 }
 
 impl<B, O> PartialEq for DecodeDifferent<B, O>
-	where
-		B: Encode + Eq + PartialEq + 'static,
-		O: Encode + Eq + PartialEq + 'static,
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
 {
 	fn eq(&self, other: &Self) -> bool {
 		self.encode() == other.encode()
@@ -79,13 +94,16 @@ impl<B, O> PartialEq for DecodeDifferent<B, O>
 }
 
 impl<B, O> Eq for DecodeDifferent<B, O>
-	where B: Encode + Eq + PartialEq + 'static, O: Encode + Eq + PartialEq + 'static
-{}
+where
+	B: Encode + Eq + PartialEq + 'static,
+	O: Encode + Eq + PartialEq + 'static,
+{
+}
 
 impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
-	where
-		B: core::fmt::Debug + Eq + 'static,
-		O: core::fmt::Debug + Eq + 'static,
+where
+	B: core::fmt::Debug + Eq + 'static,
+	O: core::fmt::Debug + Eq + 'static,
 {
 	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
 		match self {
@@ -97,11 +115,14 @@ impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
 
 #[cfg(feature = "std")]
 impl<B, O> serde::Serialize for DecodeDifferent<B, O>
-	where
-		B: serde::Serialize + 'static,
-		O: serde::Serialize + 'static,
+where
+	B: serde::Serialize + 'static,
+	O: serde::Serialize + 'static,
 {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
 		match self {
 			DecodeDifferent::Encode(b) => b.serialize(serializer),
 			DecodeDifferent::Decoded(o) => o.serialize(serializer),
@@ -109,7 +130,7 @@ impl<B, O> serde::Serialize for DecodeDifferent<B, O>
 	}
 }
 
-pub type DecodeDifferentArray<B, O=B> = DecodeDifferent<&'static [B], Vec<O>>;
+pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
 
 type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
 
@@ -132,7 +153,9 @@ pub struct FunctionArgumentMetadata {
 
 /// Newtype wrapper for support encoding functions (actual the result of the function).
 #[derive(Clone, Eq)]
-pub struct FnEncode<E>(pub fn() -> E) where E: Encode + 'static;
+pub struct FnEncode<E>(pub fn() -> E)
+where
+	E: Encode + 'static;
 
 impl<E: Encode> Encode for FnEncode<E> {
 	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
@@ -156,7 +179,10 @@ impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
 
 #[cfg(feature = "std")]
 impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
 		self.0().serialize(serializer)
 	}
 }
@@ -168,7 +194,7 @@ pub struct OuterEventMetadata {
 	pub name: DecodeDifferentStr,
 	pub events: DecodeDifferentArray<
 		(&'static str, FnEncode<&'static [EventMetadata]>),
-		(StringBuf, Vec<EventMetadata>)
+		(StringBuf, Vec<EventMetadata>),
 	>,
 }
 
@@ -249,11 +275,14 @@ impl PartialEq<DefaultByteGetter> for DefaultByteGetter {
 	}
 }
 
-impl Eq for DefaultByteGetter { }
+impl Eq for DefaultByteGetter {}
 
 #[cfg(feature = "std")]
 impl serde::Serialize for DefaultByteGetter {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
 		self.0.default_byte().serialize(serializer)
 	}
 }
@@ -374,7 +403,7 @@ pub enum RuntimeMetadata {
 /// Enum that should fail.
 #[derive(Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize))]
-pub enum RuntimeMetadataDeprecated { }
+pub enum RuntimeMetadataDeprecated {}
 
 impl Encode for RuntimeMetadataDeprecated {
 	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {}

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -349,11 +349,6 @@ pub struct StorageMetadata {
 	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
 }
 
-/// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
-
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
@@ -365,60 +360,6 @@ pub struct ExtrinsicMetadata {
 }
 
 /// The metadata of a runtime.
-/// The version ID encoded/decoded through
-/// the enum nature of `RuntimeMetadata`.
-#[derive(Eq, Encode, PartialEq, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub enum RuntimeMetadata {
-	/// Unused; enum filler.
-	V0(RuntimeMetadataDeprecated),
-	/// Version 1 for runtime metadata. No longer used.
-	V1(RuntimeMetadataDeprecated),
-	/// Version 2 for runtime metadata. No longer used.
-	V2(RuntimeMetadataDeprecated),
-	/// Version 3 for runtime metadata. No longer used.
-	V3(RuntimeMetadataDeprecated),
-	/// Version 4 for runtime metadata. No longer used.
-	V4(RuntimeMetadataDeprecated),
-	/// Version 5 for runtime metadata. No longer used.
-	V5(RuntimeMetadataDeprecated),
-	/// Version 6 for runtime metadata. No longer used.
-	V6(RuntimeMetadataDeprecated),
-	/// Version 7 for runtime metadata. No longer used.
-	V7(RuntimeMetadataDeprecated),
-	/// Version 8 for runtime metadata. No longer used.
-	V8(RuntimeMetadataDeprecated),
-	/// Version 9 for runtime metadata. No longer used.
-	V9(RuntimeMetadataDeprecated),
-	/// Version 10 for runtime metadata. No longer used.
-	V10(RuntimeMetadataDeprecated),
-	/// Version 11 for runtime metadata. No longer used.
-	V11(RuntimeMetadataDeprecated),
-	/// Version 12 for runtime metadata. No longer used.
-	V12(RuntimeMetadataDeprecated),
-	/// Version 13 for runtime metadata.
-	V13(RuntimeMetadataV13),
-}
-
-/// Enum that should fail.
-#[derive(Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "std", derive(Serialize))]
-pub enum RuntimeMetadataDeprecated {}
-
-impl Encode for RuntimeMetadataDeprecated {
-	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {}
-}
-
-impl codec::EncodeLike for RuntimeMetadataDeprecated {}
-
-#[cfg(feature = "std")]
-impl Decode for RuntimeMetadataDeprecated {
-	fn decode<I: Input>(_input: &mut I) -> Result<Self, Error> {
-		Err("Decoding is not supported".into())
-	}
-}
-
-/// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV13 {
@@ -427,9 +368,6 @@ pub struct RuntimeMetadataV13 {
 	/// Metadata of the extrinsic.
 	pub extrinsic: ExtrinsicMetadata,
 }
-
-/// The latest version of the metadata.
-pub type RuntimeMetadataLastVersion = RuntimeMetadataV13;
 
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -31,7 +31,7 @@ cfg_if::cfg_if! {
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
-/// All the metadata about an outer event.
+/// Metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
@@ -42,7 +42,7 @@ pub struct OuterEventMetadata {
 	>,
 }
 
-/// All the metadata about an event.
+/// Metadata about an event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
@@ -51,7 +51,7 @@ pub struct EventMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about one storage entry.
+/// Metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
@@ -62,7 +62,7 @@ pub struct StorageEntryMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about a module constant.
+/// Metadata about a module constant.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
@@ -72,7 +72,7 @@ pub struct ModuleConstantMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about a module error.
+/// Metadata about a module error.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
@@ -80,7 +80,7 @@ pub struct ErrorMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about errors in a module.
+/// Metadata about errors in a module.
 pub trait ModuleErrorMetadata {
 	fn metadata() -> &'static [ErrorMetadata];
 }

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -62,7 +62,7 @@ pub struct StorageEntryMetadata {
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
-/// All the metadata about one module constant.
+/// All the metadata about a module constant.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -15,177 +15,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Decodable variant of the RuntimeMetadata.
-
+use crate::decode_different::*;
 use codec::{Encode, Output};
 
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
-		use codec::{Decode, Error, Input};
+		use codec::Decode;
 		use serde::Serialize;
-
-		type StringBuf = String;
 	} else {
 		extern crate alloc;
 		use alloc::vec::Vec;
-
-		/// On `no_std` we do not support `Decode` and thus `StringBuf` is just `&'static str`.
-		/// So, if someone tries to decode this stuff on `no_std`, they will get a compilation error.
-		type StringBuf = &'static str;
 	}
 }
 
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
-
-/// A type that decodes to a different type than it encodes.
-/// The user needs to make sure that both types use the same encoding.
-///
-/// For example a `&'static [ &'static str ]` can be decoded to a `Vec<String>`.
-#[derive(Clone)]
-pub enum DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: 'static,
-{
-	Encode(B),
-	Decoded(O),
-}
-
-impl<B, O> Encode for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
-		match self {
-			DecodeDifferent::Encode(b) => b.encode_to(dest),
-			DecodeDifferent::Decoded(o) => o.encode_to(dest),
-		}
-	}
-}
-
-impl<B, O> codec::EncodeLike for DecodeDifferent<B, O>
-where
-	B: Encode + 'static,
-	O: Encode + 'static,
-{
-}
-
-#[cfg(feature = "std")]
-impl<B, O> Decode for DecodeDifferent<B, O>
-where
-	B: 'static,
-	O: Decode + 'static,
-{
-	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		<O>::decode(input).map(|val| DecodeDifferent::Decoded(val))
-	}
-}
-
-impl<B, O> PartialEq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-	fn eq(&self, other: &Self) -> bool {
-		self.encode() == other.encode()
-	}
-}
-
-impl<B, O> Eq for DecodeDifferent<B, O>
-where
-	B: Encode + Eq + PartialEq + 'static,
-	O: Encode + Eq + PartialEq + 'static,
-{
-}
-
-impl<B, O> core::fmt::Debug for DecodeDifferent<B, O>
-where
-	B: core::fmt::Debug + Eq + 'static,
-	O: core::fmt::Debug + Eq + 'static,
-{
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		match self {
-			DecodeDifferent::Encode(b) => b.fmt(f),
-			DecodeDifferent::Decoded(o) => o.fmt(f),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl<B, O> serde::Serialize for DecodeDifferent<B, O>
-where
-	B: serde::Serialize + 'static,
-	O: serde::Serialize + 'static,
-{
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			DecodeDifferent::Encode(b) => b.serialize(serializer),
-			DecodeDifferent::Decoded(o) => o.serialize(serializer),
-		}
-	}
-}
-
-pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
-
-type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
-
-/// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub struct FunctionMetadata {
-	pub name: DecodeDifferentStr,
-	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
-	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
-}
-
-/// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub struct FunctionArgumentMetadata {
-	pub name: DecodeDifferentStr,
-	pub ty: DecodeDifferentStr,
-}
-
-/// Newtype wrapper for support encoding functions (actual the result of the function).
-#[derive(Clone, Eq)]
-pub struct FnEncode<E>(pub fn() -> E)
-where
-	E: Encode + 'static;
-
-impl<E: Encode> Encode for FnEncode<E> {
-	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
-		self.0().encode_to(dest);
-	}
-}
-
-impl<E: Encode> codec::EncodeLike for FnEncode<E> {}
-
-impl<E: Encode + PartialEq> PartialEq for FnEncode<E> {
-	fn eq(&self, other: &Self) -> bool {
-		self.0().eq(&other.0())
-	}
-}
-
-impl<E: Encode + core::fmt::Debug> core::fmt::Debug for FnEncode<E> {
-	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.0().fmt(f)
-	}
-}
-
-#[cfg(feature = "std")]
-impl<E: Encode + serde::Serialize> serde::Serialize for FnEncode<E> {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		self.0().serialize(serializer)
-	}
-}
 
 /// All the metadata about an outer event.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -32,8 +32,8 @@ cfg_if::cfg_if! {
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// Metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
@@ -41,8 +41,8 @@ pub struct FunctionMetadata {
 }
 
 /// Metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -181,7 +181,7 @@ impl IntoPortable for PalletStorageMetadata {
 	}
 }
 
-/// All the metadata about one storage entry.
+/// Metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
@@ -328,7 +328,7 @@ impl IntoPortable for PalletCallMetadata {
 	}
 }
 
-/// All the metadata about a function.
+/// Metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
@@ -353,7 +353,7 @@ impl IntoPortable for FunctionMetadata {
 	}
 }
 
-/// All the metadata about a function argument.
+/// Metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
@@ -389,7 +389,7 @@ impl IntoPortable for PalletEventMetadata {
 	}
 }
 
-/// All the metadata about one pallet constant.
+/// Metadata about one pallet constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -255,7 +255,7 @@ pub enum StorageEntryType<T: Form = MetaForm> {
 		key2_hasher: StorageHasher,
 	},
 	NMap {
-		keys: Vec<T::Type>,
+		keys: T::Type,
 		hashers: Vec<StorageHasher>,
 		value: T::Type,
 	},

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -1,0 +1,476 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cfg_if::cfg_if! {
+	if #[cfg(feature = "std")] {
+		use codec::Decode;
+		use serde::Serialize;
+	}
+}
+
+use super::RuntimeMetadataPrefixed;
+use codec::Encode;
+use scale_info::prelude::vec::Vec;
+use scale_info::{
+    form::{Form, MetaForm, PortableForm},
+    meta_type, IntoPortable, PortableRegistry, Registry, TypeInfo,
+};
+
+/// Current prefix of metadata
+pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
+
+/// Type alias placeholder for `ByteGetter` equivalent. todo: [AJ] figure out what to do here
+pub type ByteGetter = Vec<u8>;
+
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV14;
+
+impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
+    fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
+        RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V14(metadata))
+    }
+}
+
+/// The metadata of a runtime.
+// todo: [AJ] add back clone derive if required (requires PortableRegistry to implement clone)
+#[derive(PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct RuntimeMetadataV14 {
+    pub types: PortableRegistry,
+    /// Metadata of all the pallets.
+    pub pallets: Vec<PalletMetadata<PortableForm>>,
+    /// Metadata of the extrinsic.
+    pub extrinsic: ExtrinsicMetadata<PortableForm>,
+}
+
+impl RuntimeMetadataV14 {
+    pub fn new(pallets: Vec<PalletMetadata>, extrinsic: ExtrinsicMetadata) -> Self {
+        let mut registry = Registry::new();
+        let pallets = registry.map_into_portable(pallets);
+        let extrinsic = extrinsic.into_portable(&mut registry);
+        Self {
+            types: registry.into(),
+            pallets,
+            extrinsic,
+        }
+    }
+}
+
+/// Metadata of the extrinsic used by the runtime.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct ExtrinsicMetadata<T: Form = MetaForm> {
+    /// The type of the extrinsic.
+    pub ty: T::Type,
+    /// Extrinsic version.
+    pub version: u8,
+    /// The signed extensions in the order they appear in the extrinsic.
+    pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
+}
+
+impl IntoPortable for ExtrinsicMetadata {
+    type Output = ExtrinsicMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        ExtrinsicMetadata {
+            ty: registry.register_type(&self.ty),
+            version: self.version,
+            signed_extensions: registry.map_into_portable(self.signed_extensions),
+        }
+    }
+}
+
+/// Metadata of an extrinsic's signed extension.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct SignedExtensionMetadata<T: Form = MetaForm> {
+    /// The unique signed extension identifier, which may be different from the type name.
+    pub identifier: T::String,
+    /// The signed extensions in the order they appear in the extrinsic.
+    pub ty: T::Type,
+}
+
+impl IntoPortable for SignedExtensionMetadata {
+    type Output = SignedExtensionMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        SignedExtensionMetadata {
+            identifier: self.identifier.into_portable(registry),
+            ty: registry.register_type(&self.ty),
+        }
+    }
+}
+
+/// All metadata about an runtime pallet.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub storage: Option<PalletStorageMetadata<T>>,
+    pub calls: Option<PalletCallMetadata<T>>,
+    pub event: Option<PalletEventMetadata<T>>,
+    pub constants: Vec<PalletConstantMetadata<T>>,
+    pub error: Option<PalletErrorMetadata<T>>,
+    /// Define the index of the pallet, this index will be used for the encoding of pallet event,
+    /// call and origin variants.
+    pub index: u8,
+}
+
+impl IntoPortable for PalletMetadata {
+    type Output = PalletMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        PalletMetadata {
+            name: self.name.into_portable(registry),
+            storage: self.storage.map(|storage| storage.into_portable(registry)),
+            calls: self.calls.map(|calls| calls.into_portable(registry)),
+            event: self.event.map(|event| event.into_portable(registry)),
+            constants: registry.map_into_portable(self.constants),
+            error: self.error.map(|error| error.into_portable(registry)),
+            index: self.index,
+        }
+    }
+}
+
+/// All metadata of the pallet's storage.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletStorageMetadata<T: Form = MetaForm> {
+    /// The common prefix used by all storage entries.
+    pub prefix: T::String,
+    pub entries: Vec<StorageEntryMetadata<T>>,
+}
+
+impl IntoPortable for PalletStorageMetadata {
+    type Output = PalletStorageMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        PalletStorageMetadata {
+            prefix: self.prefix.into_portable(registry),
+            entries: registry.map_into_portable(self.entries),
+        }
+    }
+}
+
+/// All the metadata about one storage entry.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct StorageEntryMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub modifier: StorageEntryModifier,
+    pub ty: StorageEntryType<T>,
+    pub default: ByteGetter,
+    pub documentation: Vec<T::String>,
+}
+
+impl IntoPortable for StorageEntryMetadata {
+    type Output = StorageEntryMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        StorageEntryMetadata {
+            name: self.name.into_portable(registry),
+            modifier: self.modifier,
+            ty: self.ty.into_portable(registry),
+            default: self.default,
+            documentation: registry.map_into_portable(self.documentation),
+        }
+    }
+}
+
+/// A storage entry modifier.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageEntryModifier {
+    Optional,
+    Default,
+}
+
+/// Hasher used by storage maps
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub enum StorageHasher {
+    Blake2_128,
+    Blake2_256,
+    Blake2_128Concat,
+    Twox128,
+    Twox256,
+    Twox64Concat,
+    Identity,
+}
+
+/// A storage entry type.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub enum StorageEntryType<T: Form = MetaForm> {
+    Plain(T::Type),
+    Map {
+        hasher: StorageHasher,
+        key: T::Type,
+        value: T::Type,
+        // is_linked flag previously, unused now to keep backwards compat
+        unused: bool,
+    },
+    DoubleMap {
+        hasher: StorageHasher,
+        key1: T::Type,
+        key2: T::Type,
+        value: T::Type,
+        key2_hasher: StorageHasher,
+    },
+}
+
+impl IntoPortable for StorageEntryType {
+    type Output = StorageEntryType<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        match self {
+            Self::Plain(plain) => StorageEntryType::Plain(registry.register_type(&plain)),
+            Self::Map {
+                hasher,
+                key,
+                value,
+                unused,
+            } => StorageEntryType::Map {
+                hasher,
+                key: registry.register_type(&key),
+                value: registry.register_type(&value),
+                unused,
+            },
+            Self::DoubleMap {
+                hasher,
+                key1,
+                key2,
+                value,
+                key2_hasher,
+            } => StorageEntryType::DoubleMap {
+                hasher,
+                key1: registry.register_type(&key1),
+                key2: registry.register_type(&key2),
+                value: registry.register_type(&value),
+                key2_hasher,
+            },
+        }
+    }
+}
+
+/// Metadata for all calls in a pallet
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletCallMetadata<T: Form = MetaForm> {
+    /// The corresponding enum type for the pallet call.
+    pub ty: T::Type,
+    pub calls: Vec<FunctionMetadata<T>>,
+}
+
+impl IntoPortable for PalletCallMetadata {
+    type Output = PalletCallMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        PalletCallMetadata {
+            ty: registry.register_type(&self.ty),
+            calls: registry.map_into_portable(self.calls),
+        }
+    }
+}
+
+/// All the metadata about a function.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct FunctionMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub arguments: Vec<FunctionArgumentMetadata<T>>,
+    pub documentation: Vec<T::String>,
+}
+
+impl IntoPortable for FunctionMetadata {
+    type Output = FunctionMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        FunctionMetadata {
+            name: self.name.into_portable(registry),
+            arguments: registry.map_into_portable(self.arguments),
+            documentation: registry.map_into_portable(self.documentation),
+        }
+    }
+}
+
+/// All the metadata about a function argument.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub ty: T::Type,
+}
+
+impl IntoPortable for FunctionArgumentMetadata {
+    type Output = FunctionArgumentMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        FunctionArgumentMetadata {
+            name: self.name.into_portable(registry),
+            ty: registry.register_type(&self.ty),
+        }
+    }
+}
+
+/// Metadata about the pallet event type.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+pub struct PalletEventMetadata<T: Form = MetaForm> {
+    pub ty: T::Type,
+}
+
+impl IntoPortable for PalletEventMetadata {
+    type Output = PalletEventMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        PalletEventMetadata {
+            ty: registry.register_type(&self.ty),
+        }
+    }
+}
+
+/// All the metadata about one pallet constant.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletConstantMetadata<T: Form = MetaForm> {
+    pub name: T::String,
+    pub ty: T::Type,
+    pub value: ByteGetter,
+    pub documentation: Vec<T::String>,
+}
+
+impl IntoPortable for PalletConstantMetadata {
+    type Output = PalletConstantMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        PalletConstantMetadata {
+            name: self.name.into_portable(registry),
+            ty: registry.register_type(&self.ty),
+            value: self.value,
+            documentation: registry.map_into_portable(self.documentation),
+        }
+    }
+}
+
+/// Metadata about a pallet error.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize")))]
+pub struct PalletErrorMetadata<T: Form = MetaForm> {
+    /// The error type information.
+    pub ty: T::Type,
+}
+
+impl IntoPortable for PalletErrorMetadata {
+    type Output = PalletErrorMetadata<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        PalletErrorMetadata {
+            ty: registry.register_type(&self.ty),
+        }
+    }
+}
+
+/// A type specification.
+///
+/// This contains the actual type as well as an optional compile-time
+/// known displayed representation of the type. This is useful for cases
+/// where the type is used through a type alias in order to provide
+/// information about the alias name.
+///
+/// # Examples
+///
+/// Consider the following Rust function:
+/// ```no_compile
+/// fn is_sorted(input: &[i32], pred: Predicate) -> bool;
+/// ```
+/// In this above example `input` would have no displayable name,
+/// `pred`'s display name is `Predicate` and the display name of
+/// the return type is simply `bool`. Note that `Predicate` could
+/// simply be a type alias to `fn(i32, i32) -> Ordering`.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+feature = "std",
+serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct TypeSpec<T: Form = MetaForm> {
+    /// The actual type.
+    pub ty: T::Type,
+    /// The compile-time known displayed representation of the type.
+    pub name: T::String,
+}
+
+impl IntoPortable for TypeSpec {
+    type Output = TypeSpec<PortableForm>;
+
+    fn into_portable(self, registry: &mut Registry) -> Self::Output {
+        TypeSpec {
+            ty: registry.register_type(&self.ty),
+            name: self.name.into_portable(registry),
+        }
+    }
+}
+
+impl TypeSpec {
+    /// Creates a new type specification without a display name.
+    pub fn new<T>(name: &'static str) -> Self
+        where
+            T: TypeInfo + 'static,
+    {
+        Self {
+            ty: meta_type::<T>(),
+            name,
+        }
+    }
+}

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -254,6 +254,11 @@ pub enum StorageEntryType<T: Form = MetaForm> {
 		value: T::Type,
 		key2_hasher: StorageHasher,
 	},
+	NMap {
+		keys: Vec<T::Type>,
+		hashers: Vec<StorageHasher>,
+		value: T::Type,
+	},
 }
 
 impl IntoPortable for StorageEntryType {
@@ -285,6 +290,15 @@ impl IntoPortable for StorageEntryType {
 				key2: registry.register_type(&key2),
 				value: registry.register_type(&value),
 				key2_hasher,
+			},
+			StorageEntryType::NMap {
+				keys,
+				hashers,
+				value,
+			} => StorageEntryType::NMap {
+				keys: registry.register_types(keys),
+				hashers,
+				value: registry.register_type(&value),
 			},
 		}
 	}

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -477,7 +477,7 @@ impl IntoPortable for TypeSpec {
 }
 
 impl TypeSpec {
-	/// Creates a new type specification without a display name.
+	/// Creates a new type specification with a display name.
 	pub fn new<T>(name: &'static str) -> Self
 	where
 		T: TypeInfo + 'static,

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -296,7 +296,7 @@ impl IntoPortable for StorageEntryType {
 				hashers,
 				value,
 			} => StorageEntryType::NMap {
-				keys: registry.register_types(keys),
+				keys: registry.register_type(&keys),
 				hashers,
 				value: registry.register_type(&value),
 			},

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -26,8 +26,8 @@ use super::RuntimeMetadataPrefixed;
 use codec::Encode;
 use scale_info::prelude::vec::Vec;
 use scale_info::{
-    form::{Form, MetaForm, PortableForm},
-    meta_type, IntoPortable, PortableRegistry, Registry, TypeInfo,
+	form::{Form, MetaForm, PortableForm},
+	meta_type, IntoPortable, PortableRegistry, Registry, TypeInfo,
 };
 
 /// Current prefix of metadata
@@ -39,9 +39,9 @@ pub type ByteGetter = Vec<u8>;
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV14;
 
 impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
-    fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
-        RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V14(metadata))
-    }
+	fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
+		RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V14(metadata))
+	}
 }
 
 /// The metadata of a runtime.
@@ -49,357 +49,357 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 #[derive(PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct RuntimeMetadataV14 {
-    pub types: PortableRegistry,
-    /// Metadata of all the pallets.
-    pub pallets: Vec<PalletMetadata<PortableForm>>,
-    /// Metadata of the extrinsic.
-    pub extrinsic: ExtrinsicMetadata<PortableForm>,
+	pub types: PortableRegistry,
+	/// Metadata of all the pallets.
+	pub pallets: Vec<PalletMetadata<PortableForm>>,
+	/// Metadata of the extrinsic.
+	pub extrinsic: ExtrinsicMetadata<PortableForm>,
 }
 
 impl RuntimeMetadataV14 {
-    pub fn new(pallets: Vec<PalletMetadata>, extrinsic: ExtrinsicMetadata) -> Self {
-        let mut registry = Registry::new();
-        let pallets = registry.map_into_portable(pallets);
-        let extrinsic = extrinsic.into_portable(&mut registry);
-        Self {
-            types: registry.into(),
-            pallets,
-            extrinsic,
-        }
-    }
+	pub fn new(pallets: Vec<PalletMetadata>, extrinsic: ExtrinsicMetadata) -> Self {
+		let mut registry = Registry::new();
+		let pallets = registry.map_into_portable(pallets);
+		let extrinsic = extrinsic.into_portable(&mut registry);
+		Self {
+			types: registry.into(),
+			pallets,
+			extrinsic,
+		}
+	}
 }
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
-    /// The type of the extrinsic.
-    pub ty: T::Type,
-    /// Extrinsic version.
-    pub version: u8,
-    /// The signed extensions in the order they appear in the extrinsic.
-    pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
+	/// The type of the extrinsic.
+	pub ty: T::Type,
+	/// Extrinsic version.
+	pub version: u8,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
 }
 
 impl IntoPortable for ExtrinsicMetadata {
-    type Output = ExtrinsicMetadata<PortableForm>;
+	type Output = ExtrinsicMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        ExtrinsicMetadata {
-            ty: registry.register_type(&self.ty),
-            version: self.version,
-            signed_extensions: registry.map_into_portable(self.signed_extensions),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		ExtrinsicMetadata {
+			ty: registry.register_type(&self.ty),
+			version: self.version,
+			signed_extensions: registry.map_into_portable(self.signed_extensions),
+		}
+	}
 }
 
 /// Metadata of an extrinsic's signed extension.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
-    /// The unique signed extension identifier, which may be different from the type name.
-    pub identifier: T::String,
-    /// The signed extensions in the order they appear in the extrinsic.
-    pub ty: T::Type,
+	/// The unique signed extension identifier, which may be different from the type name.
+	pub identifier: T::String,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub ty: T::Type,
 }
 
 impl IntoPortable for SignedExtensionMetadata {
-    type Output = SignedExtensionMetadata<PortableForm>;
+	type Output = SignedExtensionMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        SignedExtensionMetadata {
-            identifier: self.identifier.into_portable(registry),
-            ty: registry.register_type(&self.ty),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		SignedExtensionMetadata {
+			identifier: self.identifier.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+		}
+	}
 }
 
 /// All metadata about an runtime pallet.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub storage: Option<PalletStorageMetadata<T>>,
-    pub calls: Option<PalletCallMetadata<T>>,
-    pub event: Option<PalletEventMetadata<T>>,
-    pub constants: Vec<PalletConstantMetadata<T>>,
-    pub error: Option<PalletErrorMetadata<T>>,
-    /// Define the index of the pallet, this index will be used for the encoding of pallet event,
-    /// call and origin variants.
-    pub index: u8,
+	pub name: T::String,
+	pub storage: Option<PalletStorageMetadata<T>>,
+	pub calls: Option<PalletCallMetadata<T>>,
+	pub event: Option<PalletEventMetadata<T>>,
+	pub constants: Vec<PalletConstantMetadata<T>>,
+	pub error: Option<PalletErrorMetadata<T>>,
+	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
+	/// call and origin variants.
+	pub index: u8,
 }
 
 impl IntoPortable for PalletMetadata {
-    type Output = PalletMetadata<PortableForm>;
+	type Output = PalletMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        PalletMetadata {
-            name: self.name.into_portable(registry),
-            storage: self.storage.map(|storage| storage.into_portable(registry)),
-            calls: self.calls.map(|calls| calls.into_portable(registry)),
-            event: self.event.map(|event| event.into_portable(registry)),
-            constants: registry.map_into_portable(self.constants),
-            error: self.error.map(|error| error.into_portable(registry)),
-            index: self.index,
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletMetadata {
+			name: self.name.into_portable(registry),
+			storage: self.storage.map(|storage| storage.into_portable(registry)),
+			calls: self.calls.map(|calls| calls.into_portable(registry)),
+			event: self.event.map(|event| event.into_portable(registry)),
+			constants: registry.map_into_portable(self.constants),
+			error: self.error.map(|error| error.into_portable(registry)),
+			index: self.index,
+		}
+	}
 }
 
 /// All metadata of the pallet's storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletStorageMetadata<T: Form = MetaForm> {
-    /// The common prefix used by all storage entries.
-    pub prefix: T::String,
-    pub entries: Vec<StorageEntryMetadata<T>>,
+	/// The common prefix used by all storage entries.
+	pub prefix: T::String,
+	pub entries: Vec<StorageEntryMetadata<T>>,
 }
 
 impl IntoPortable for PalletStorageMetadata {
-    type Output = PalletStorageMetadata<PortableForm>;
+	type Output = PalletStorageMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        PalletStorageMetadata {
-            prefix: self.prefix.into_portable(registry),
-            entries: registry.map_into_portable(self.entries),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletStorageMetadata {
+			prefix: self.prefix.into_portable(registry),
+			entries: registry.map_into_portable(self.entries),
+		}
+	}
 }
 
 /// All the metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub modifier: StorageEntryModifier,
-    pub ty: StorageEntryType<T>,
-    pub default: ByteGetter,
-    pub documentation: Vec<T::String>,
+	pub name: T::String,
+	pub modifier: StorageEntryModifier,
+	pub ty: StorageEntryType<T>,
+	pub default: ByteGetter,
+	pub documentation: Vec<T::String>,
 }
 
 impl IntoPortable for StorageEntryMetadata {
-    type Output = StorageEntryMetadata<PortableForm>;
+	type Output = StorageEntryMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        StorageEntryMetadata {
-            name: self.name.into_portable(registry),
-            modifier: self.modifier,
-            ty: self.ty.into_portable(registry),
-            default: self.default,
-            documentation: registry.map_into_portable(self.documentation),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		StorageEntryMetadata {
+			name: self.name.into_portable(registry),
+			modifier: self.modifier,
+			ty: self.ty.into_portable(registry),
+			default: self.default,
+			documentation: registry.map_into_portable(self.documentation),
+		}
+	}
 }
 
 /// A storage entry modifier.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {
-    Optional,
-    Default,
+	Optional,
+	Default,
 }
 
 /// Hasher used by storage maps
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageHasher {
-    Blake2_128,
-    Blake2_256,
-    Blake2_128Concat,
-    Twox128,
-    Twox256,
-    Twox64Concat,
-    Identity,
+	Blake2_128,
+	Blake2_256,
+	Blake2_128Concat,
+	Twox128,
+	Twox256,
+	Twox64Concat,
+	Identity,
 }
 
 /// A storage entry type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub enum StorageEntryType<T: Form = MetaForm> {
-    Plain(T::Type),
-    Map {
-        hasher: StorageHasher,
-        key: T::Type,
-        value: T::Type,
-        // is_linked flag previously, unused now to keep backwards compat
-        unused: bool,
-    },
-    DoubleMap {
-        hasher: StorageHasher,
-        key1: T::Type,
-        key2: T::Type,
-        value: T::Type,
-        key2_hasher: StorageHasher,
-    },
+	Plain(T::Type),
+	Map {
+		hasher: StorageHasher,
+		key: T::Type,
+		value: T::Type,
+		// is_linked flag previously, unused now to keep backwards compat
+		unused: bool,
+	},
+	DoubleMap {
+		hasher: StorageHasher,
+		key1: T::Type,
+		key2: T::Type,
+		value: T::Type,
+		key2_hasher: StorageHasher,
+	},
 }
 
 impl IntoPortable for StorageEntryType {
-    type Output = StorageEntryType<PortableForm>;
+	type Output = StorageEntryType<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        match self {
-            Self::Plain(plain) => StorageEntryType::Plain(registry.register_type(&plain)),
-            Self::Map {
-                hasher,
-                key,
-                value,
-                unused,
-            } => StorageEntryType::Map {
-                hasher,
-                key: registry.register_type(&key),
-                value: registry.register_type(&value),
-                unused,
-            },
-            Self::DoubleMap {
-                hasher,
-                key1,
-                key2,
-                value,
-                key2_hasher,
-            } => StorageEntryType::DoubleMap {
-                hasher,
-                key1: registry.register_type(&key1),
-                key2: registry.register_type(&key2),
-                value: registry.register_type(&value),
-                key2_hasher,
-            },
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		match self {
+			Self::Plain(plain) => StorageEntryType::Plain(registry.register_type(&plain)),
+			Self::Map {
+				hasher,
+				key,
+				value,
+				unused,
+			} => StorageEntryType::Map {
+				hasher,
+				key: registry.register_type(&key),
+				value: registry.register_type(&value),
+				unused,
+			},
+			Self::DoubleMap {
+				hasher,
+				key1,
+				key2,
+				value,
+				key2_hasher,
+			} => StorageEntryType::DoubleMap {
+				hasher,
+				key1: registry.register_type(&key1),
+				key2: registry.register_type(&key2),
+				value: registry.register_type(&value),
+				key2_hasher,
+			},
+		}
+	}
 }
 
 /// Metadata for all calls in a pallet
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletCallMetadata<T: Form = MetaForm> {
-    /// The corresponding enum type for the pallet call.
-    pub ty: T::Type,
-    pub calls: Vec<FunctionMetadata<T>>,
+	/// The corresponding enum type for the pallet call.
+	pub ty: T::Type,
+	pub calls: Vec<FunctionMetadata<T>>,
 }
 
 impl IntoPortable for PalletCallMetadata {
-    type Output = PalletCallMetadata<PortableForm>;
+	type Output = PalletCallMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        PalletCallMetadata {
-            ty: registry.register_type(&self.ty),
-            calls: registry.map_into_portable(self.calls),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletCallMetadata {
+			ty: registry.register_type(&self.ty),
+			calls: registry.map_into_portable(self.calls),
+		}
+	}
 }
 
 /// All the metadata about a function.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct FunctionMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub arguments: Vec<FunctionArgumentMetadata<T>>,
-    pub documentation: Vec<T::String>,
+	pub name: T::String,
+	pub arguments: Vec<FunctionArgumentMetadata<T>>,
+	pub documentation: Vec<T::String>,
 }
 
 impl IntoPortable for FunctionMetadata {
-    type Output = FunctionMetadata<PortableForm>;
+	type Output = FunctionMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        FunctionMetadata {
-            name: self.name.into_portable(registry),
-            arguments: registry.map_into_portable(self.arguments),
-            documentation: registry.map_into_portable(self.documentation),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		FunctionMetadata {
+			name: self.name.into_portable(registry),
+			arguments: registry.map_into_portable(self.arguments),
+			documentation: registry.map_into_portable(self.documentation),
+		}
+	}
 }
 
 /// All the metadata about a function argument.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct FunctionArgumentMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub ty: T::Type,
+	pub name: T::String,
+	pub ty: T::Type,
 }
 
 impl IntoPortable for FunctionArgumentMetadata {
-    type Output = FunctionArgumentMetadata<PortableForm>;
+	type Output = FunctionArgumentMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        FunctionArgumentMetadata {
-            name: self.name.into_portable(registry),
-            ty: registry.register_type(&self.ty),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		FunctionArgumentMetadata {
+			name: self.name.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+		}
+	}
 }
 
 /// Metadata about the pallet event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
-    pub ty: T::Type,
+	pub ty: T::Type,
 }
 
 impl IntoPortable for PalletEventMetadata {
-    type Output = PalletEventMetadata<PortableForm>;
+	type Output = PalletEventMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        PalletEventMetadata {
-            ty: registry.register_type(&self.ty),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletEventMetadata {
+			ty: registry.register_type(&self.ty),
+		}
+	}
 }
 
 /// All the metadata about one pallet constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletConstantMetadata<T: Form = MetaForm> {
-    pub name: T::String,
-    pub ty: T::Type,
-    pub value: ByteGetter,
-    pub documentation: Vec<T::String>,
+	pub name: T::String,
+	pub ty: T::Type,
+	pub value: ByteGetter,
+	pub documentation: Vec<T::String>,
 }
 
 impl IntoPortable for PalletConstantMetadata {
-    type Output = PalletConstantMetadata<PortableForm>;
+	type Output = PalletConstantMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        PalletConstantMetadata {
-            name: self.name.into_portable(registry),
-            ty: registry.register_type(&self.ty),
-            value: self.value,
-            documentation: registry.map_into_portable(self.documentation),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletConstantMetadata {
+			name: self.name.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+			value: self.value,
+			documentation: registry.map_into_portable(self.documentation),
+		}
+	}
 }
 
 /// Metadata about a pallet error.
@@ -407,18 +407,18 @@ impl IntoPortable for PalletConstantMetadata {
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize")))]
 pub struct PalletErrorMetadata<T: Form = MetaForm> {
-    /// The error type information.
-    pub ty: T::Type,
+	/// The error type information.
+	pub ty: T::Type,
 }
 
 impl IntoPortable for PalletErrorMetadata {
-    type Output = PalletErrorMetadata<PortableForm>;
+	type Output = PalletErrorMetadata<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        PalletErrorMetadata {
-            ty: registry.register_type(&self.ty),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletErrorMetadata {
+			ty: registry.register_type(&self.ty),
+		}
+	}
 }
 
 /// A type specification.
@@ -441,36 +441,36 @@ impl IntoPortable for PalletErrorMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-feature = "std",
-serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+	feature = "std",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct TypeSpec<T: Form = MetaForm> {
-    /// The actual type.
-    pub ty: T::Type,
-    /// The compile-time known displayed representation of the type.
-    pub name: T::String,
+	/// The actual type.
+	pub ty: T::Type,
+	/// The compile-time known displayed representation of the type.
+	pub name: T::String,
 }
 
 impl IntoPortable for TypeSpec {
-    type Output = TypeSpec<PortableForm>;
+	type Output = TypeSpec<PortableForm>;
 
-    fn into_portable(self, registry: &mut Registry) -> Self::Output {
-        TypeSpec {
-            ty: registry.register_type(&self.ty),
-            name: self.name.into_portable(registry),
-        }
-    }
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		TypeSpec {
+			ty: registry.register_type(&self.ty),
+			name: self.name.into_portable(registry),
+		}
+	}
 }
 
 impl TypeSpec {
-    /// Creates a new type specification without a display name.
-    pub fn new<T>(name: &'static str) -> Self
-        where
-            T: TypeInfo + 'static,
-    {
-        Self {
-            ty: meta_type::<T>(),
-            name,
-        }
-    }
+	/// Creates a new type specification without a display name.
+	pub fn new<T>(name: &'static str) -> Self
+	where
+		T: TypeInfo + 'static,
+	{
+		Self {
+			ty: meta_type::<T>(),
+			name,
+		}
+	}
 }


### PR DESCRIPTION
New `v13` just been introduced in https://github.com/paritytech/substrate/pull/8635 so we need move the new `scale-info` stuff to `v14` and add the Storage `NMap` variant.

# todo:

- [x] Add new StorageNMap metadata to `v14`
- [x] Update CI checks to check `v14`