### PR TITLE
Reexport all the types from the latest version

### DIFF
--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -46,6 +46,10 @@ pub mod v13;
 #[cfg(feature = "v14")]
 pub mod v14;
 
+// Reexport all the types from the latest version
+#[cfg(feature = "v14")]
+pub use self::v14::*;
+
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -46,7 +46,9 @@ pub mod v13;
 #[cfg(feature = "v14")]
 pub mod v14;
 
-// Reexport all the types from the latest version
+// Reexport all the types from the latest version.
+//
+// When a new version becomes available, update this.
 #[cfg(feature = "v14")]
 pub use self::v14::*;
 


### PR DESCRIPTION
In order that the user doesn't need to fully qualify the path including the version to the types, when using the latest available version.

So when `v15` comes along we just update the reexport to that.