### PR TITLE
Remove is_linked from v14

### DIFF
--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -240,8 +240,6 @@ pub enum StorageEntryType<T: Form = MetaForm> {
 		hasher: StorageHasher,
 		key: T::Type,
 		value: T::Type,
-		// is_linked flag previously, unused now to keep backwards compat
-		unused: bool,
 	},
 	DoubleMap {
 		hasher: StorageHasher,


### PR DESCRIPTION
This was something carried over from a changes that was done where the version was not bumped. It probably should have been removed in v13 already. but rather late than never.