### PR TITLE
Add `additional_signed` field for `SignedExtension` payload data

### DIFF
--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -103,8 +103,10 @@ impl IntoPortable for ExtrinsicMetadata {
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
 	/// The unique signed extension identifier, which may be different from the type name.
 	pub identifier: T::String,
-	/// The signed extensions in the order they appear in the extrinsic.
+	/// The type of the signed extension, with the data to be included in the extrinsic.
 	pub ty: T::Type,
+	/// The type of the additional signed data, with the data to be included in the signed payload
+	pub additional_signed: T::Type,
 }
 
 impl IntoPortable for SignedExtensionMetadata {
@@ -114,6 +116,7 @@ impl IntoPortable for SignedExtensionMetadata {
 		SignedExtensionMetadata {
 			identifier: self.identifier.into_portable(registry),
 			ty: registry.register_type(&self.ty),
+			additional_signed: registry.register_type(&self.additional_signed),
 		}
 	}
 }

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -264,11 +264,7 @@ impl IntoPortable for StorageEntryType {
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		match self {
 			Self::Plain(plain) => StorageEntryType::Plain(registry.register_type(&plain)),
-			Self::Map {
-				hasher,
-				key,
-				value,
-			} => StorageEntryType::Map {
+			Self::Map { hasher, key, value } => StorageEntryType::Map {
 				hasher,
 				key: registry.register_type(&key),
 				value: registry.register_type(&value),


### PR DESCRIPTION
Adds the type of `SignedExtension::AdditionalSigned` to the `SignedExtensionMetadata`.

For @jacogr  as part of https://github.com/polkadot-js/api/pull/3759