### PR TITLE
Add docs feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,6 @@ jobs:
         with:
           command:                 check
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --all-features
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --all-features
 
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,10 +116,11 @@ jobs:
           command:                 check
           toolchain:               stable
           args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v14
-      - name:                      Checking all versions
+      - name:                      Checking all features
         uses:                      actions-rs/cargo@master
         with:
           command:                 check
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12,v13,v14
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --all-features
+
 

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -25,7 +25,6 @@ v12 = []
 v13 = []
 v14 = ["scale-info"]
 std = [
-	"docs",
 	"codec/std",
 	"scale-info/std",
 	"scale-info/serde",

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -20,10 +20,12 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 [features]
 default = ["std", "v14"]
+docs = ["scale-info/docs"]
 v12 = []
 v13 = []
 v14 = ["scale-info"]
 std = [
+	"docs",
 	"codec/std",
 	"scale-info/std",
 	"scale-info/serde",

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -241,9 +241,12 @@ impl StorageEntryMetadata<MetaForm> {
 	}
 }
 
-impl StorageEntryMetadata<PortableForm> {
+impl<T> StorageEntryMetadata<T>
+where
+	T: Form
+{
 	/// Get the documentation.
-	pub fn docs(&self) -> &[<PortableForm as Form>::String] {
+	pub fn docs(&self) -> &[T::String] {
 		self.docs.as_slice()
 	}
 }
@@ -437,9 +440,12 @@ impl PalletConstantMetadata {
 	}
 }
 
-impl PalletConstantMetadata<PortableForm> {
+impl PalletConstantMetadata<T>
+where
+	T: Form
+{
 	/// Get the documentation.
-	pub fn docs(&self) -> &[<PortableForm as Form>::String] {
+	pub fn docs(&self) -> &[T::String] {
 		self.docs.as_slice()
 	}
 }

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -24,7 +24,10 @@ cfg_if::cfg_if! {
 
 use super::RuntimeMetadataPrefixed;
 use codec::Encode;
-use scale_info::prelude::vec::Vec;
+use scale_info::prelude::{
+	string::String,
+	vec::Vec,
+};
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	IntoPortable, MetaType, PortableRegistry, Registry,

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -234,8 +234,8 @@ impl StorageEntryMetadata<MetaForm> {
 	}
 
 	#[cfg(not(feature = "docs"))]
-	/// Docs feature is not enabled so this is a no-op.
 	#[inline]
+	/// Docs feature is not enabled so this is a no-op.
 	pub fn with_docs(self, _docs: &[&'static str]) -> Self {
 		self
 	}
@@ -433,8 +433,8 @@ impl PalletConstantMetadata {
 	}
 
 	#[cfg(not(feature = "docs"))]
-	/// Docs feature is not enabled so this is a no-op.
 	#[inline]
+	/// Docs feature is not enabled so this is a no-op.
 	pub fn with_docs(self, _docs: &[&'static str]) -> Self {
 		self
 	}

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -236,7 +236,7 @@ impl StorageEntryMetadata<MetaForm> {
 	#[cfg(not(feature = "docs"))]
 	/// Docs feature is not enabled so this is a no-op.
 	#[inline]
-	pub fn with_docs(mut self, docs: &[&'static str]) -> Self {
+	pub fn with_docs(mut self, _docs: &[&'static str]) -> Self {
 		self
 	}
 }
@@ -432,7 +432,7 @@ impl PalletConstantMetadata {
 	#[cfg(not(feature = "docs"))]
 	/// Docs feature is not enabled so this is a no-op.
 	#[inline]
-	pub fn with_docs(mut self, docs: &[&'static str]) -> Self {
+	pub fn with_docs(mut self, _docs: &[&'static str]) -> Self {
 		self
 	}
 }

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -243,7 +243,7 @@ impl StorageEntryMetadata<MetaForm> {
 
 impl StorageEntryMetadata<PortableForm> {
 	/// Get the documentation.
-	pub fn docs(&self) -> &[&str] {
+	pub fn docs(&self) -> &[<PortableForm as Form>::String] {
 		self.docs.as_slice()
 	}
 }
@@ -439,8 +439,8 @@ impl PalletConstantMetadata {
 
 impl PalletConstantMetadata<PortableForm> {
 	/// Get the documentation.
-	pub fn docs(&self) -> &[&str] {
-		&self.docs
+	pub fn docs(&self) -> &[<PortableForm as Form>::String] {
+		self.docs.as_slice()
 	}
 }
 

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -24,10 +24,7 @@ cfg_if::cfg_if! {
 
 use super::RuntimeMetadataPrefixed;
 use codec::Encode;
-use scale_info::prelude::{
-	string::String,
-	vec::Vec,
-};
+use scale_info::prelude::{string::String, vec::Vec};
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	IntoPortable, MetaType, PortableRegistry, Registry,

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -192,7 +192,7 @@ pub struct StorageEntryMetadata<T: Form = MetaForm> {
 	pub modifier: StorageEntryModifier,
 	pub ty: StorageEntryType<T>,
 	pub default: Vec<u8>,
-	pub docs: Vec<T::String>,
+	docs: Vec<T::String>,
 }
 
 impl IntoPortable for StorageEntryMetadata {
@@ -206,6 +206,45 @@ impl IntoPortable for StorageEntryMetadata {
 			default: self.default,
 			docs: registry.map_into_portable(self.docs),
 		}
+	}
+}
+
+impl StorageEntryMetadata<MetaForm> {
+	/// Create a new [`StorageEntryMetadata`].
+	pub fn new(
+		name: &'static str,
+		modifier: StorageEntryModifier,
+		ty: StorageEntryType<MetaForm>,
+		default: Vec<u8>,
+	) -> Self {
+		StorageEntryMetadata {
+			name,
+			modifier,
+			ty,
+			default,
+			docs: Vec::new(),
+		}
+	}
+
+	#[cfg(feature = "docs")]
+	/// Set the documentation.
+	pub fn with_docs(mut self, docs: &[&'static str]) -> Self {
+		self.docs = docs.to_vec();
+		self
+	}
+
+	#[cfg(not(feature = "docs"))]
+	/// Docs feature is not enabled so this is a no-op.
+	#[inline]
+	pub fn with_docs(mut self, docs: &[&'static str]) -> Self {
+		self
+	}
+}
+
+impl StorageEntryMetadata<PortableForm> {
+	/// Get the documentation.
+	pub fn docs(&self) -> &[String] {
+		&self.docs
 	}
 }
 
@@ -357,7 +396,7 @@ pub struct PalletConstantMetadata<T: Form = MetaForm> {
 	pub name: T::String,
 	pub ty: T::Type,
 	pub value: Vec<u8>,
-	pub docs: Vec<T::String>,
+	docs: Vec<T::String>,
 }
 
 impl IntoPortable for PalletConstantMetadata {
@@ -370,6 +409,38 @@ impl IntoPortable for PalletConstantMetadata {
 			value: self.value,
 			docs: registry.map_into_portable(self.docs),
 		}
+	}
+}
+
+impl PalletConstantMetadata {
+	pub fn new(name: &'static str, ty: MetaType, value: Vec<u8>) -> Self {
+		Self {
+			name,
+			ty,
+			value,
+			docs: Vec::new(),
+		}
+	}
+
+	#[cfg(feature = "docs")]
+	/// Set the documentation.
+	pub fn with_docs(mut self, docs: &[&'static str]) -> Self {
+		self.docs = docs.to_vec();
+		self
+	}
+
+	#[cfg(not(feature = "docs"))]
+	/// Docs feature is not enabled so this is a no-op.
+	#[inline]
+	pub fn with_docs(mut self, docs: &[&'static str]) -> Self {
+		self
+	}
+}
+
+impl PalletConstantMetadata<PortableForm> {
+	/// Get the documentation.
+	pub fn docs(&self) -> &[String] {
+		&self.docs
 	}
 }
 

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
 
 use super::RuntimeMetadataPrefixed;
 use codec::Encode;
-use scale_info::prelude::{string::String, vec::Vec};
+use scale_info::prelude::vec::Vec;
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	IntoPortable, MetaType, PortableRegistry, Registry,
@@ -236,15 +236,15 @@ impl StorageEntryMetadata<MetaForm> {
 	#[cfg(not(feature = "docs"))]
 	/// Docs feature is not enabled so this is a no-op.
 	#[inline]
-	pub fn with_docs(mut self, _docs: &[&'static str]) -> Self {
+	pub fn with_docs(self, _docs: &[&'static str]) -> Self {
 		self
 	}
 }
 
 impl StorageEntryMetadata<PortableForm> {
 	/// Get the documentation.
-	pub fn docs(&self) -> &[String] {
-		&self.docs
+	pub fn docs(&self) -> &[&str] {
+		self.docs.as_slice()
 	}
 }
 
@@ -432,14 +432,14 @@ impl PalletConstantMetadata {
 	#[cfg(not(feature = "docs"))]
 	/// Docs feature is not enabled so this is a no-op.
 	#[inline]
-	pub fn with_docs(mut self, _docs: &[&'static str]) -> Self {
+	pub fn with_docs(self, _docs: &[&'static str]) -> Self {
 		self
 	}
 }
 
 impl PalletConstantMetadata<PortableForm> {
 	/// Get the documentation.
-	pub fn docs(&self) -> &[String] {
+	pub fn docs(&self) -> &[&str] {
 		&self.docs
 	}
 }

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -243,7 +243,7 @@ impl StorageEntryMetadata<MetaForm> {
 
 impl<T> StorageEntryMetadata<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Get the documentation.
 	pub fn docs(&self) -> &[T::String] {
@@ -442,7 +442,7 @@ impl PalletConstantMetadata {
 
 impl PalletConstantMetadata<T>
 where
-	T: Form
+	T: Form,
 {
 	/// Get the documentation.
 	pub fn docs(&self) -> &[T::String] {

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -440,7 +440,7 @@ impl PalletConstantMetadata {
 	}
 }
 
-impl PalletConstantMetadata<T>
+impl<T> PalletConstantMetadata<T>
 where
 	T: Form,
 {


### PR DESCRIPTION
Add a `docs` feature which when enabled will cause docs to be captured.

Adds a builder method to types with docs (`StorageEntryMetadata` and `PalletConstantMetadata`), which becomes an inline no-op when the feature is disabled. The compiler should then optimize away the static strngs.