### PR TITLE
Add function to return version from metadata

### DIFF
--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -149,6 +149,29 @@ pub enum RuntimeMetadata {
 	V14(OpaqueMetadata),
 }
 
+impl RuntimeMetadata {
+	/// Get the version number of the metadata.
+	pub fn version(&self) -> u32 {
+		match self {
+			RuntimeMetadata::V0(_) => 0,
+			RuntimeMetadata::V1(_) => 1,
+			RuntimeMetadata::V2(_) => 2,
+			RuntimeMetadata::V3(_) => 3,
+			RuntimeMetadata::V4(_) => 4,
+			RuntimeMetadata::V5(_) => 5,
+			RuntimeMetadata::V6(_) => 6,
+			RuntimeMetadata::V7(_) => 7,
+			RuntimeMetadata::V8(_) => 8,
+			RuntimeMetadata::V9(_) => 9,
+			RuntimeMetadata::V10(_) => 10,
+			RuntimeMetadata::V11(_) => 11,
+			RuntimeMetadata::V12(_) => 12,
+			RuntimeMetadata::V13(_) => 13,
+			RuntimeMetadata::V14(_) => 14,
+		}
+	}
+}
+
 /// Stores the encoded `RuntimeMetadata` as raw bytes.
 #[derive(Encode, Eq, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]


### PR DESCRIPTION
Plucked from https://github.com/paritytech/frame-metadata/pull/24/files#diff-361abe92f6544eac70ee0471d4128328b07f6991bc01d7cc70fe919c55077ff4R116

Just becasue it's something that would be handy for us in desub land :)

Not sure how far off that draft PR is; feel free to close this if it's not too far off anyway!