### PR TITLE
Document all v14, v13 and most of v8 items

### DIFF
--- a/frame-metadata/src/decode_different.rs
+++ b/frame-metadata/src/decode_different.rs
@@ -20,6 +20,7 @@ use codec::{Encode, Output};
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
 		use codec::{Decode, Error, Input};
+		/// On `std` the `StringBuf` used by [`DecodeDifferent`] is just a `String`.
 		pub type StringBuf = String;
 	} else {
 		extern crate alloc;
@@ -41,7 +42,9 @@ where
 	B: 'static,
 	O: 'static,
 {
+	/// Encodable variant of the value (doesn't need to be decodeable).
 	Encode(B),
+	/// Encodable & decodeable variant of the value.
 	Decoded(O),
 }
 
@@ -123,8 +126,10 @@ where
 	}
 }
 
+/// An array type that decodes as a `Vec`.
 pub type DecodeDifferentArray<B, O = B> = DecodeDifferent<&'static [B], Vec<O>>;
 
+/// A string type that decodes as a [`StringBuf`].
 pub type DecodeDifferentStr = DecodeDifferent<&'static str, StringBuf>;
 
 /// Newtype wrapper for support encoding functions (actual the result of the function).

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -18,6 +18,7 @@
 //! Decodable variant of the RuntimeMetadata.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
 
 cfg_if::cfg_if! {
 	if #[cfg(feature = "std")] {
@@ -34,6 +35,7 @@ cfg_if::cfg_if! {
 
 use codec::{Encode, Output};
 
+/// A type that decodes to a different type than it encodes.
 #[cfg(any(
 	feature = "v13",
 	feature = "v12",
@@ -45,24 +47,31 @@ use codec::{Encode, Output};
 ))]
 pub mod decode_different;
 
+/// Metadata v8
 #[cfg(feature = "v8")]
 pub mod v8;
 
+/// Metadata v9
 #[cfg(feature = "v9")]
 pub mod v9;
 
+/// Metadata v10
 #[cfg(feature = "v10")]
 pub mod v10;
 
+/// Metadata v11
 #[cfg(feature = "v11")]
 pub mod v11;
 
+/// Metadata v12
 #[cfg(feature = "v12")]
 pub mod v12;
 
+/// Metadata v13
 #[cfg(feature = "v13")]
 pub mod v13;
 
+/// Metadata v14
 #[cfg(feature = "v14")]
 pub mod v14;
 

--- a/frame-metadata/src/v10.rs
+++ b/frame-metadata/src/v10.rs
@@ -197,7 +197,11 @@ pub enum StorageEntryType {
 	},
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {

--- a/frame-metadata/src/v10.rs
+++ b/frame-metadata/src/v10.rs
@@ -18,6 +18,8 @@
 //! Metadata Version 10. Networks like Kusama contain this version on-chain.
 //! Chains old enough to contain this metadata need a way to decode it.
 
+#![allow(missing_docs)]
+
 use crate::decode_different::*;
 use codec::{Encode, Output};
 

--- a/frame-metadata/src/v11.rs
+++ b/frame-metadata/src/v11.rs
@@ -18,6 +18,8 @@
 //! Metadata Version 11. Networks like Kusama contain this version on-chain.
 //! Chains old enough to contain this metadata need a way to decode it.
 
+#![allow(missing_docs)]
+
 use crate::decode_different::*;
 use codec::{Encode, Output};
 

--- a/frame-metadata/src/v11.rs
+++ b/frame-metadata/src/v11.rs
@@ -199,7 +199,11 @@ pub enum StorageEntryType {
 	},
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -18,6 +18,8 @@
 //! Metadata Version 12. Networks like Kusama contain this version on-chain.
 //! Chains old enough to contain this metadata need a way to decode it.
 
+#![allow(missing_docs)]
+
 use crate::decode_different::*;
 use codec::{Encode, Output};
 

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -199,7 +199,11 @@ pub enum StorageEntryType {
 	},
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -38,8 +38,11 @@ pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
+	/// Function name.
 	pub name: DecodeDifferentStr,
+	/// A list of arguments this function takes.
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+	/// Function documentation.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -47,7 +50,9 @@ pub struct FunctionMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
+	/// Name of the variable for the argument.
 	pub name: DecodeDifferentStr,
+	/// Type of the parameter.
 	pub ty: DecodeDifferentStr,
 }
 
@@ -55,7 +60,9 @@ pub struct FunctionArgumentMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
+	/// Name of the event.
 	pub name: DecodeDifferentStr,
+	/// A list of event details.
 	pub events: DecodeDifferentArray<
 		(&'static str, FnEncode<&'static [EventMetadata]>),
 		(StringBuf, Vec<EventMetadata>),
@@ -66,8 +73,11 @@ pub struct OuterEventMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
+	/// Name of the event.
 	pub name: DecodeDifferentStr,
+	/// Arguments of the event.
 	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
+	/// Documentation of the event.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -75,10 +85,15 @@ pub struct EventMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
+	/// Variable name of the storage entry.
 	pub name: DecodeDifferentStr,
+	/// A storage modifier of the storage entry (is it optional? does it have a default value?).
 	pub modifier: StorageEntryModifier,
+	/// Type of the value stored in the entry.
 	pub ty: StorageEntryType,
+	/// Default value (SCALE encoded).
 	pub default: ByteGetter,
+	/// Storage entry documentation.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -86,9 +101,13 @@ pub struct StorageEntryMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
+	/// Name of the module constant.
 	pub name: DecodeDifferentStr,
+	/// Type of the module constant.
 	pub ty: DecodeDifferentStr,
+	/// Value stored in the constant (SCALE encoded).
 	pub value: ByteGetter,
+	/// Documentation of the constant.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -96,12 +115,15 @@ pub struct ModuleConstantMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
+	/// Name of the error.
 	pub name: DecodeDifferentStr,
+	/// Error variant documentation.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// Metadata about errors in a module.
 pub trait ModuleErrorMetadata {
+	/// Returns the error metadata.
 	fn metadata() -> &'static [ErrorMetadata];
 }
 
@@ -113,6 +135,7 @@ impl ModuleErrorMetadata for &'static str {
 
 /// A technical trait to store lazy initiated vec value as static dyn pointer.
 pub trait DefaultByte: Send + Sync {
+	/// A default value (SCALE encoded).
 	fn default_byte(&self) -> Vec<u8>;
 }
 
@@ -161,12 +184,19 @@ impl core::fmt::Debug for DefaultByteGetter {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageHasher {
+	/// 128-bit Blake2 hash.
 	Blake2_128,
+	/// 256-bit Blake2 hash.
 	Blake2_256,
+	/// Multiple 128-bit Blake2 hashes concatenated.
 	Blake2_128Concat,
+	/// 128-bit XX hash.
 	Twox128,
+	/// 256-bit XX hash.
 	Twox256,
+	/// Multiple 64-bit XX hashes concatenated.
 	Twox64Concat,
+	/// Identity hashing (no hashing).
 	Identity,
 }
 
@@ -174,33 +204,51 @@ pub enum StorageHasher {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryType {
+	/// Plain storage entry (just the value).
 	Plain(DecodeDifferentStr),
+	/// A storage map.
 	Map {
+		/// Hasher type for the keys.
 		hasher: StorageHasher,
+		/// Key type.
 		key: DecodeDifferentStr,
+		/// Value type.
 		value: DecodeDifferentStr,
-		// is_linked flag previously, unused now to keep backwards compat
+		/// is_linked flag previously, unused now to keep backwards compat
 		unused: bool,
 	},
+	/// Storage Double Map.
 	DoubleMap {
+		/// Hasher type for the keys.
 		hasher: StorageHasher,
+		/// First key type.
 		key1: DecodeDifferentStr,
+		/// Second key type.
 		key2: DecodeDifferentStr,
+		/// Value type.
 		value: DecodeDifferentStr,
+		/// Hasher for the second key.
 		key2_hasher: StorageHasher,
 	},
+	/// Storage multi map.
 	NMap {
+		/// Key types.
 		keys: DecodeDifferentArray<&'static str, StringBuf>,
+		/// Key hashers.
 		hashers: DecodeDifferentArray<StorageHasher>,
+		/// Value type.
 		value: DecodeDifferentStr,
 	},
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicating if a storage entry has a default value (`Default`) or not
+/// ('Optional').
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
+	/// The storage entry is optional.
 	Optional,
+	/// The storage entry has a default value.
 	Default,
 }
 
@@ -210,6 +258,7 @@ pub enum StorageEntryModifier {
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
+	/// Storage entries.
 	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
 }
 
@@ -233,15 +282,21 @@ pub struct RuntimeMetadataV13 {
 	pub extrinsic: ExtrinsicMetadata,
 }
 
-/// All metadata about an runtime module.
+/// All metadata about a runtime module.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleMetadata {
+	/// Module name.
 	pub name: DecodeDifferentStr,
+	/// Module storage.
 	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
+	/// Module calls.
 	pub calls: ODFnA<FunctionMetadata>,
+	/// Module Event type.
 	pub event: ODFnA<EventMetadata>,
+	/// Module constants.
 	pub constants: DFnA<ModuleConstantMetadata>,
+	/// Module errors.
 	pub errors: DFnA<ErrorMetadata>,
 	/// Define the index of the module, this index will be used for the encoding of module event,
 	/// call and origin variants.

--- a/frame-metadata/src/v13.rs
+++ b/frame-metadata/src/v13.rs
@@ -241,14 +241,17 @@ pub enum StorageEntryType {
 	},
 }
 
-/// A storage entry modifier indicating if a storage entry has a default value (`Default`) or not
-/// ('Optional').
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
-	/// The storage entry is optional.
+	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
-	/// The storage entry has a default value.
+	/// The storage entry returns `T::Default` if the key is not present.
 	Default,
 }
 

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -232,14 +232,17 @@ impl IntoPortable for StorageEntryMetadata {
 	}
 }
 
-/// A storage entry modifier indicating if a storage entry has a default value (`Default`) or not
-/// ('Optional').
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {
-	/// The storage entry is optional.
+	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
-	/// The storage entry has a default value.
+	/// The storage entry returns `T::Default` if the key is not present.
 	Default,
 }
 

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -33,6 +33,7 @@ use scale_info::{
 /// Current prefix of metadata
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
+/// Latest runtime metadata
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV14;
 
 impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
@@ -45,6 +46,7 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct RuntimeMetadataV14 {
+	/// Type registry containing all types used in the metadata.
 	pub types: PortableRegistry,
 	/// Metadata of all the pallets.
 	pub pallets: Vec<PalletMetadata<PortableForm>>,
@@ -55,6 +57,7 @@ pub struct RuntimeMetadataV14 {
 }
 
 impl RuntimeMetadataV14 {
+	/// Create a new instance of [`RuntimeMetadataV14`].
 	pub fn new(
 		pallets: Vec<PalletMetadata>,
 		extrinsic: ExtrinsicMetadata,
@@ -137,11 +140,17 @@ impl IntoPortable for SignedExtensionMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletMetadata<T: Form = MetaForm> {
+	/// Pallet name.
 	pub name: T::String,
+	/// Pallet storage metadata.
 	pub storage: Option<PalletStorageMetadata<T>>,
+	/// Pallet calls metadata.
 	pub calls: Option<PalletCallMetadata<T>>,
+	/// Pallet event metadata.
 	pub event: Option<PalletEventMetadata<T>>,
+	/// Pallet constants metadata.
 	pub constants: Vec<PalletConstantMetadata<T>>,
+	/// Pallet error metadata.
 	pub error: Option<PalletErrorMetadata<T>>,
 	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
 	/// call and origin variants.
@@ -174,6 +183,7 @@ impl IntoPortable for PalletMetadata {
 pub struct PalletStorageMetadata<T: Form = MetaForm> {
 	/// The common prefix used by all storage entries.
 	pub prefix: T::String,
+	/// Metadata for all storage entries.
 	pub entries: Vec<StorageEntryMetadata<T>>,
 }
 
@@ -196,10 +206,15 @@ impl IntoPortable for PalletStorageMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
+	/// Variable name of the storage entry.
 	pub name: T::String,
+	/// An `Option` modifier of that storage entry.
 	pub modifier: StorageEntryModifier,
+	/// Type of the value stored in the entry.
 	pub ty: StorageEntryType<T>,
+	/// Default value (SCALE encoded).
 	pub default: Vec<u8>,
+	/// Storage entry documentation.
 	pub docs: Vec<T::String>,
 }
 
@@ -217,11 +232,14 @@ impl IntoPortable for StorageEntryMetadata {
 	}
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicating if a storage entry has a default value (`Default`) or not
+/// ('Optional').
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {
+	/// The storage entry is optional.
 	Optional,
+	/// The storage entry has a default value.
 	Default,
 }
 
@@ -229,16 +247,23 @@ pub enum StorageEntryModifier {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageHasher {
+	/// 128-bit Blake2 hash.
 	Blake2_128,
+	/// 256-bit Blake2 hash.
 	Blake2_256,
+	/// Multiple 128-bit Blake2 hashes concatenated.
 	Blake2_128Concat,
+	/// 128-bit XX hash.
 	Twox128,
+	/// 256-bit XX hash.
 	Twox256,
+	/// Multiple 64-bit XX hashes concatenated.
 	Twox64Concat,
+	/// Identity hashing (no hashing).
 	Identity,
 }
 
-/// A storage entry type.
+/// A type of storage value.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
@@ -246,7 +271,9 @@ pub enum StorageHasher {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub enum StorageEntryType<T: Form = MetaForm> {
+	/// Plain storage entry (just the value).
 	Plain(T::Type),
+	/// A storage map.
 	Map {
 		/// One or more hashers, should be one hasher per key element.
 		hashers: Vec<StorageHasher>,
@@ -304,10 +331,11 @@ impl From<MetaType> for PalletCallMetadata {
 	}
 }
 
-/// Metadata about the pallet event type.
+/// Metadata about the pallet Event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
+	/// The Event type.
 	pub ty: T::Type,
 }
 
@@ -335,9 +363,13 @@ impl From<MetaType> for PalletEventMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletConstantMetadata<T: Form = MetaForm> {
+	/// Name of the pallet constant.
 	pub name: T::String,
+	/// Type of the pallet constant.
 	pub ty: T::Type,
+	/// Value stored in the constant (SCALE encoded).
 	pub value: Vec<u8>,
+	/// Documentation of the constant.
 	pub docs: Vec<T::String>,
 }
 

--- a/frame-metadata/src/v8.rs
+++ b/frame-metadata/src/v8.rs
@@ -17,6 +17,8 @@
 
 //! Metadata Version 8. Chains old enough to contain this metadata need a way to decode it.
 
+#![allow(missing_docs)]
+
 use crate::decode_different::*;
 use codec::{Encode, Output};
 
@@ -43,8 +45,11 @@ pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct FunctionMetadata {
+	/// Function name.
 	pub name: DecodeDifferentStr,
+	/// A list of arguments this function takes.
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
+	/// Function documentation.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -52,7 +57,9 @@ pub struct FunctionMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct FunctionArgumentMetadata {
+	/// Name of the variable for the argument.
 	pub name: DecodeDifferentStr,
+	/// Type of the parameter.
 	pub ty: DecodeDifferentStr,
 }
 
@@ -60,7 +67,9 @@ pub struct FunctionArgumentMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct OuterEventMetadata {
+	/// Name of the event.
 	pub name: DecodeDifferentStr,
+	/// A list of event details.
 	pub events: DecodeDifferentArray<
 		(&'static str, FnEncode<&'static [EventMetadata]>),
 		(StringBuf, Vec<EventMetadata>),
@@ -71,8 +80,11 @@ pub struct OuterEventMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct EventMetadata {
+	/// Name of the event.
 	pub name: DecodeDifferentStr,
+	/// Arguments of the event.
 	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
+	/// Documentation of the event.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -80,10 +92,15 @@ pub struct EventMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct StorageEntryMetadata {
+	/// Variable name of the storage entry.
 	pub name: DecodeDifferentStr,
+	/// A storage modifier of the storage entry (is it optional? does it have a default value?).
 	pub modifier: StorageEntryModifier,
+	/// Type of the value stored in the entry.
 	pub ty: StorageEntryType,
+	/// Default value (SCALE encoded).
 	pub default: ByteGetter,
+	/// Storage entry documentation.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -91,9 +108,13 @@ pub struct StorageEntryMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct ModuleConstantMetadata {
+	/// Name of the module constant.
 	pub name: DecodeDifferentStr,
+	/// Type of the module constant.
 	pub ty: DecodeDifferentStr,
+	/// Value stored in the constant (SCALE encoded).
 	pub value: ByteGetter,
+	/// Documentation of the constant.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
@@ -101,12 +122,15 @@ pub struct ModuleConstantMetadata {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct ErrorMetadata {
+	/// Name of the error.
 	pub name: DecodeDifferentStr,
+	/// Error variant documentation.
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
 }
 
 /// All the metadata about errors in a module.
 pub trait ModuleErrorMetadata {
+	/// Returns error metadata.
 	fn metadata() -> &'static [ErrorMetadata];
 }
 
@@ -118,6 +142,7 @@ impl ModuleErrorMetadata for &'static str {
 
 /// A technical trait to store lazy initiated vec value as static dyn pointer.
 pub trait DefaultByte: Send + Sync {
+	/// A default value (SCALE encoded).
 	fn default_byte(&self) -> Vec<u8>;
 }
 
@@ -167,10 +192,15 @@ impl std::fmt::Debug for DefaultByteGetter {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub enum StorageHasher {
+	/// 128-bit Blake2 hash.
 	Blake2_128,
+	/// 256-bit Blake2 hash.
 	Blake2_256,
+	/// 128-bit XX hash.
 	Twox128,
+	/// 256-bit XX hash.
 	Twox256,
+	/// 64-bit XX hashes concatentation.
 	Twox64Concat,
 }
 
@@ -178,27 +208,41 @@ pub enum StorageHasher {
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub enum StorageEntryType {
+	/// Plain storage entry (just the value).
 	Plain(DecodeDifferentStr),
+	/// A storage map.
 	Map {
+		/// Hasher type for the keys.
 		hasher: StorageHasher,
+		/// Key type.
 		key: DecodeDifferentStr,
+		/// Value type.
 		value: DecodeDifferentStr,
 		is_linked: bool,
 	},
+	/// Storage Double Map.
 	DoubleMap {
+		/// Hasher type for the keys.
 		hasher: StorageHasher,
+		/// First key type.
 		key1: DecodeDifferentStr,
+		/// Second key type.
 		key2: DecodeDifferentStr,
+		/// Value type.
 		value: DecodeDifferentStr,
+		/// Hasher for the second key.
 		key2_hasher: StorageHasher,
 	},
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicating if a storage entry has a default value (`Default`) or not
+/// ('Optional').
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub enum StorageEntryModifier {
+	/// The storage entry is optional.
 	Optional,
+	/// The storage entry has a default value.
 	Default,
 }
 
@@ -221,10 +265,11 @@ pub struct RuntimeMetadataV8 {
 /// The latest version of the metadata.
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV8;
 
-/// All metadata about an runtime module.
+/// All metadata about a runtime module.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct ModuleMetadata {
+	/// Module name.
 	pub name: DecodeDifferentStr,
 	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
 	pub calls: ODFnA<FunctionMetadata>,

--- a/frame-metadata/src/v8.rs
+++ b/frame-metadata/src/v8.rs
@@ -235,14 +235,17 @@ pub enum StorageEntryType {
 	},
 }
 
-/// A storage entry modifier indicating if a storage entry has a default value (`Default`) or not
-/// ('Optional').
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub enum StorageEntryModifier {
-	/// The storage entry is optional.
+	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
-	/// The storage entry has a default value.
+	/// The storage entry returns `T::Default` if the key is not present.
 	Default,
 }
 

--- a/frame-metadata/src/v9.rs
+++ b/frame-metadata/src/v9.rs
@@ -197,7 +197,11 @@ pub enum StorageEntryType {
 	},
 }
 
-/// A storage entry modifier.
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {

--- a/frame-metadata/src/v9.rs
+++ b/frame-metadata/src/v9.rs
@@ -18,6 +18,8 @@
 //! Metadata Version 9. Networks like/as old as Kusama start here.
 //! Chains old enough to contain this metadata need a way to decode it.
 
+#![allow(missing_docs)]
+
 use crate::decode_different::*;
 use codec::{Encode, Output};
 


### PR DESCRIPTION
Also enables warnings for missing docs.

Follow up PRs should document v8 –> v12 and remove the `allow(missing_docs)` attribute on those modules.﻿
