### PR TITLE
add no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,4 +122,9 @@ jobs:
           command:                 check
           toolchain:               stable
           args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12,v13,v14
-
+      - name:                      Checking fully featured wasm
+        uses:                      actions-rs/cargo@v1
+        with:
+          command:                 check
+          toolchain:               stable
+          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features decode,serde_full,v14

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,12 +69,20 @@ jobs:
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain stable
 ## Check Stage
-      - name:                      Checking wasm32
+      - name:                      Checking wasm32 (v14)
         uses:                      actions-rs/cargo@v1
+        uses:                      taiki-e/install-action@cargo-hack
         with:
-          command:                 check
+          command:                 hack
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --target wasm32-unknown-unknown --no-default-features
+          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4 --target wasm32-unknown-unknown
+      - name:                      Checking wasm32 (all features)
+        uses:                      actions-rs/cargo@v1
+        uses:                      taiki-e/install-action@cargo-hack
+        with:
+          command:                 hack
+          toolchain:               stable
+          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4 --target wasm32-unknown-unknown
 
   check-features:
     name:                          Check Features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,39 +92,17 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
 ## Check Stage
-      - name:                      Checking without any features
+      - name:                      Checking v14 feature combinations (native)
         uses:                      actions-rs/cargo@v1
+        uses:                      taiki-e/install-action@cargo-hack
         with:
-          command:                 check
+          command:                 hack
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features
-      - name:                      Checking v12
+          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4
+      - name:                      Checking feature combinations excluding decode/serde_full (native)
         uses:                      actions-rs/cargo@v1
+        uses:                      taiki-e/install-action@cargo-hack
         with:
-          command:                 check
+          command:                 hack
           toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12
-      - name:                      Checking v13
-        uses:                      actions-rs/cargo@v1
-        with:
-          command:                 check
-          toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v13
-      - name:                      Checking v14
-        uses:                      actions-rs/cargo@v1
-        with:
-          command:                 check
-          toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v14
-      - name:                      Checking all versions
-        uses:                      actions-rs/cargo@v1
-        with:
-          command:                 check
-          toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features v12,v13,v14
-      - name:                      Checking fully featured wasm
-        uses:                      actions-rs/cargo@v1
-        with:
-          command:                 check
-          toolchain:               stable
-          args:                    --manifest-path ./frame-metadata/Cargo.toml --no-default-features --features decode,serde_full,v14
+          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 cfg-if = "1.0.0"
 scale-info = { version = "2.0.0", default-features = false, optional = true, features = ["derive"] }
-serde = { version = "1.0.101", optional = true, features = ["derive"] }
+serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
 
 [features]
 default = ["std", "v14"]
@@ -28,10 +28,17 @@ v12 = []
 v13 = []
 legacy = ["v13", "v12", "v11", "v10", "v9", "v8"]
 v14 = ["scale-info"]
-std = [
-	"codec/std",
-	"scale-info/std",
+
+full_derive = [
 	"scale-info/serde",
 	"scale-info/decode",
 	"serde",
+	"serde/alloc",
+]
+
+std = [
+	"full_derive",
+	"codec/std",
+	"scale-info/std",
+	"serde/std",
 ]

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -29,15 +29,18 @@ v13 = []
 legacy = ["v13", "v12", "v11", "v10", "v9", "v8"]
 v14 = ["scale-info"]
 
-full_derive = [
+# Serde support without relying on std features
+serde_codec = [
 	"scale-info/serde",
-	"scale-info/decode",
 	"serde",
 	"serde/alloc",
 ]
+# Scale decode support without relying on std features
+decode = ["scale-info/decode"]
 
 std = [
-	"full_derive",
+	"decode",
+	"serde_codec",
 	"codec/std",
 	"scale-info/std",
 	"serde/std",

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -30,7 +30,7 @@ legacy = ["v13", "v12", "v11", "v10", "v9", "v8"]
 v14 = ["scale-info"]
 
 # Serde support without relying on std features
-serde_codec = [
+serde_full = [
 	"scale-info/serde",
 	"serde",
 	"serde/alloc",
@@ -40,7 +40,7 @@ decode = ["scale-info/decode"]
 
 std = [
 	"decode",
-	"serde_codec",
+	"serde_full",
 	"codec/std",
 	"scale-info/std",
 	"serde/std",

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -19,15 +19,33 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#[cfg(all(
+	feature = "full_derive",
+	any(
+		feature = "v13",
+		feature = "v12",
+		feature = "v11",
+		feature = "v10",
+		feature = "v9",
+		feature = "v8",
+		feature = "legacy"
+	),
+	not(feature = "std")
+))]
+compile_error!("full_derive for metadata prior to v14 requires std!");
 
 cfg_if::cfg_if! {
-	if #[cfg(feature = "std")] {
+	if #[cfg(feature = "full_derive")] {
 		use codec::{Decode, Error, Input};
 		use serde::{
 			Deserialize,
 			Serialize,
 		};
-	} else {
+	}
+}
+
+cfg_if::cfg_if! {
+	if #[cfg(not(feature = "std"))] {
 		extern crate alloc;
 		use alloc::vec::Vec;
 	}
@@ -83,7 +101,7 @@ pub use self::v14::*;
 
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
 
 impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
@@ -96,7 +114,7 @@ impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
 #[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 pub enum RuntimeMetadata {
 	/// Unused; enum filler.
 	V0(RuntimeMetadataDeprecated),
@@ -183,12 +201,12 @@ impl RuntimeMetadata {
 
 /// Stores the encoded `RuntimeMetadata` as raw bytes.
 #[derive(Encode, Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Deserialize, Debug))]
 pub struct OpaqueMetadata(pub Vec<u8>);
 
 /// Enum that should fail.
 #[derive(Eq, PartialEq)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Serialize, Deserialize, Debug))]
 pub enum RuntimeMetadataDeprecated {}
 
 impl Encode for RuntimeMetadataDeprecated {
@@ -197,7 +215,7 @@ impl Encode for RuntimeMetadataDeprecated {
 
 impl codec::EncodeLike for RuntimeMetadataDeprecated {}
 
-#[cfg(feature = "std")]
+#[cfg(feature = "full_derive")]
 impl Decode for RuntimeMetadataDeprecated {
 	fn decode<I: Input>(_input: &mut I) -> Result<Self, Error> {
 		Err("Decoding is not supported".into())

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -35,10 +35,7 @@
 compile_error!("decode/serde_codec features prior to v14 require std");
 
 #[cfg(feature = "serde_codec")]
-use serde::{
-	Deserialize,
-	Serialize,
-};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "decode")]
 use codec::{Decode, Error, Input};

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -96,7 +96,7 @@ pub mod v14;
 pub use self::v14::*;
 
 /// Metadata prefixed by a u32 for reserved usage
-#[derive(Eq, Encode, PartialEq)]
+#[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
@@ -110,7 +110,7 @@ impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
 /// The metadata of a runtime.
 /// The version ID encoded/decoded through
 /// the enum nature of `RuntimeMetadata`.
-#[derive(Eq, Encode, PartialEq)]
+#[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub enum RuntimeMetadata {
@@ -198,13 +198,13 @@ impl RuntimeMetadata {
 }
 
 /// Stores the encoded `RuntimeMetadata` as raw bytes.
-#[derive(Encode, Eq, PartialEq)]
+#[derive(Encode, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize, Deserialize))]
 pub struct OpaqueMetadata(pub Vec<u8>);
 
 /// Enum that should fail.
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "serde_full", derive(Serialize, Deserialize))]
 pub enum RuntimeMetadataDeprecated {}
 

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #[cfg(all(
-	any(feature = "decode", feature = "serde_codec"),
+	any(feature = "decode", feature = "serde_full"),
 	any(
 		feature = "v13",
 		feature = "v12",
@@ -32,9 +32,9 @@
 	),
 	not(feature = "std")
 ))]
-compile_error!("decode/serde_codec features prior to v14 require std");
+compile_error!("decode and serde_full features prior to v14 require std");
 
-#[cfg(feature = "serde_codec")]
+#[cfg(feature = "serde_full")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "decode")]
@@ -98,7 +98,7 @@ pub use self::v14::*;
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
 
 impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
@@ -112,7 +112,7 @@ impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
 /// the enum nature of `RuntimeMetadata`.
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub enum RuntimeMetadata {
 	/// Unused; enum filler.
 	V0(RuntimeMetadataDeprecated),
@@ -200,12 +200,12 @@ impl RuntimeMetadata {
 /// Stores the encoded `RuntimeMetadata` as raw bytes.
 #[derive(Encode, Eq, PartialEq)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize, Deserialize))]
 pub struct OpaqueMetadata(pub Vec<u8>);
 
 /// Enum that should fail.
 #[derive(Eq, PartialEq)]
-#[cfg_attr(feature = "serde_codec", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize, Deserialize))]
 pub enum RuntimeMetadataDeprecated {}
 
 impl Encode for RuntimeMetadataDeprecated {

--- a/frame-metadata/src/v10.rs
+++ b/frame-metadata/src/v10.rs
@@ -43,8 +43,8 @@ cfg_if::cfg_if! {
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
@@ -52,16 +52,16 @@ pub struct FunctionMetadata {
 }
 
 /// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
 }
 
 /// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
 	pub name: DecodeDifferentStr,
 	pub events: DecodeDifferentArray<
@@ -71,8 +71,8 @@ pub struct OuterEventMetadata {
 }
 
 /// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
@@ -80,8 +80,8 @@ pub struct EventMetadata {
 }
 
 /// All the metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
 	pub name: DecodeDifferentStr,
 	pub modifier: StorageEntryModifier,
@@ -91,8 +91,8 @@ pub struct StorageEntryMetadata {
 }
 
 /// All the metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
@@ -101,8 +101,8 @@ pub struct ModuleConstantMetadata {
 }
 
 /// All the metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
 	pub name: DecodeDifferentStr,
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
@@ -166,8 +166,8 @@ impl core::fmt::Debug for DefaultByteGetter {
 }
 
 /// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageHasher {
 	Blake2_128,
 	Blake2_256,
@@ -178,8 +178,8 @@ pub enum StorageHasher {
 }
 
 /// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryType {
 	Plain(DecodeDifferentStr),
 	Map {
@@ -202,16 +202,16 @@ pub enum StorageEntryType {
 ///
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
 	Optional,
 	Default,
 }
 
 /// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
@@ -219,15 +219,15 @@ pub struct StorageMetadata {
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV10 {
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleMetadata {
 	pub name: DecodeDifferentStr,
 	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,

--- a/frame-metadata/src/v11.rs
+++ b/frame-metadata/src/v11.rs
@@ -43,8 +43,8 @@ cfg_if::cfg_if! {
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
@@ -52,16 +52,16 @@ pub struct FunctionMetadata {
 }
 
 /// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
 }
 
 /// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
 	pub name: DecodeDifferentStr,
 	pub events: DecodeDifferentArray<
@@ -71,8 +71,8 @@ pub struct OuterEventMetadata {
 }
 
 /// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
@@ -80,8 +80,8 @@ pub struct EventMetadata {
 }
 
 /// All the metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
 	pub name: DecodeDifferentStr,
 	pub modifier: StorageEntryModifier,
@@ -91,8 +91,8 @@ pub struct StorageEntryMetadata {
 }
 
 /// All the metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
@@ -101,8 +101,8 @@ pub struct ModuleConstantMetadata {
 }
 
 /// All the metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
 	pub name: DecodeDifferentStr,
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
@@ -166,8 +166,8 @@ impl core::fmt::Debug for DefaultByteGetter {
 }
 
 /// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageHasher {
 	Blake2_128,
 	Blake2_256,
@@ -179,8 +179,8 @@ pub enum StorageHasher {
 }
 
 /// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryType {
 	Plain(DecodeDifferentStr),
 	Map {
@@ -204,16 +204,16 @@ pub enum StorageEntryType {
 ///
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
 	Optional,
 	Default,
 }
 
 /// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
@@ -221,8 +221,8 @@ pub struct StorageMetadata {
 }
 
 /// Metadata of the extrinsic used by the runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ExtrinsicMetadata {
 	/// Extrinsic version.
 	pub version: u8,
@@ -231,8 +231,8 @@ pub struct ExtrinsicMetadata {
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV11 {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
@@ -241,8 +241,8 @@ pub struct RuntimeMetadataV11 {
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleMetadata {
 	pub name: DecodeDifferentStr,
 	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -43,8 +43,8 @@ cfg_if::cfg_if! {
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// Metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
@@ -52,16 +52,16 @@ pub struct FunctionMetadata {
 }
 
 /// Metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
 }
 
 /// Metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
 	pub name: DecodeDifferentStr,
 	pub events: DecodeDifferentArray<
@@ -71,8 +71,8 @@ pub struct OuterEventMetadata {
 }
 
 /// Metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
@@ -80,8 +80,8 @@ pub struct EventMetadata {
 }
 
 /// Metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
 	pub name: DecodeDifferentStr,
 	pub modifier: StorageEntryModifier,
@@ -91,8 +91,8 @@ pub struct StorageEntryMetadata {
 }
 
 /// Metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
@@ -101,8 +101,8 @@ pub struct ModuleConstantMetadata {
 }
 
 /// Metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
 	pub name: DecodeDifferentStr,
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
@@ -166,8 +166,8 @@ impl core::fmt::Debug for DefaultByteGetter {
 }
 
 /// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageHasher {
 	Blake2_128,
 	Blake2_256,
@@ -179,8 +179,8 @@ pub enum StorageHasher {
 }
 
 /// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryType {
 	Plain(DecodeDifferentStr),
 	Map {
@@ -204,16 +204,16 @@ pub enum StorageEntryType {
 ///
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
 	Optional,
 	Default,
 }
 
 /// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
@@ -221,8 +221,8 @@ pub struct StorageMetadata {
 }
 
 /// Metadata of the extrinsic used by the runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ExtrinsicMetadata {
 	/// Extrinsic version.
 	pub version: u8,
@@ -231,8 +231,8 @@ pub struct ExtrinsicMetadata {
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV12 {
 	/// Metadata of all the modules.
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
@@ -241,8 +241,8 @@ pub struct RuntimeMetadataV12 {
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleMetadata {
 	pub name: DecodeDifferentStr,
 	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 cfg_if::cfg_if! {
-	if #[cfg(feature = "std")] {
+	if #[cfg(feature = "full_derive")] {
 		use codec::Decode;
 		use serde::Serialize;
 	}
@@ -44,7 +44,7 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 
 /// The metadata of a runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 pub struct RuntimeMetadataV14 {
 	/// Type registry containing all types used in the metadata.
 	pub types: PortableRegistry,
@@ -78,9 +78,9 @@ impl RuntimeMetadataV14 {
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
@@ -106,9 +106,9 @@ impl IntoPortable for ExtrinsicMetadata {
 
 /// Metadata of an extrinsic's signed extension.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
@@ -134,9 +134,9 @@ impl IntoPortable for SignedExtensionMetadata {
 
 /// All metadata about an runtime pallet.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletMetadata<T: Form = MetaForm> {
@@ -175,9 +175,9 @@ impl IntoPortable for PalletMetadata {
 
 /// All metadata of the pallet's storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletStorageMetadata<T: Form = MetaForm> {
@@ -200,9 +200,9 @@ impl IntoPortable for PalletStorageMetadata {
 
 /// Metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
@@ -238,7 +238,7 @@ impl IntoPortable for StorageEntryMetadata {
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 pub enum StorageEntryModifier {
 	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
@@ -248,7 +248,7 @@ pub enum StorageEntryModifier {
 
 /// Hasher used by storage maps
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 pub enum StorageHasher {
 	/// 128-bit Blake2 hash.
 	Blake2_128,
@@ -268,9 +268,9 @@ pub enum StorageHasher {
 
 /// A type of storage value.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub enum StorageEntryType<T: Form = MetaForm> {
@@ -308,9 +308,9 @@ impl IntoPortable for StorageEntryType {
 
 /// Metadata for all calls in a pallet
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletCallMetadata<T: Form = MetaForm> {
@@ -336,7 +336,7 @@ impl From<MetaType> for PalletCallMetadata {
 
 /// Metadata about the pallet Event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
 	/// The Event type.
 	pub ty: T::Type,
@@ -360,9 +360,9 @@ impl From<MetaType> for PalletEventMetadata {
 
 /// Metadata about one pallet constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
 #[cfg_attr(
-	feature = "std",
+	feature = "full_derive",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletConstantMetadata<T: Form = MetaForm> {
@@ -391,8 +391,11 @@ impl IntoPortable for PalletConstantMetadata {
 
 /// Metadata about a pallet error.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
-#[cfg_attr(feature = "std", serde(bound(serialize = "T::Type: Serialize")))]
+#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(
+	feature = "full_derive",
+	serde(bound(serialize = "T::Type: Serialize"))
+)]
 pub struct PalletErrorMetadata<T: Form = MetaForm> {
 	/// The error type information.
 	pub ty: T::Type,

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -17,7 +17,7 @@
 
 #[cfg(feature = "decode")]
 use codec::Decode;
-#[cfg(feature = "serde_codec")]
+#[cfg(feature = "serde_full")]
 use serde::Serialize;
 
 use super::RuntimeMetadataPrefixed;
@@ -43,7 +43,7 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 /// The metadata of a runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct RuntimeMetadataV14 {
 	/// Type registry containing all types used in the metadata.
 	pub types: PortableRegistry,
@@ -78,9 +78,9 @@ impl RuntimeMetadataV14 {
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
@@ -107,9 +107,9 @@ impl IntoPortable for ExtrinsicMetadata {
 /// Metadata of an extrinsic's signed extension.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
@@ -136,9 +136,9 @@ impl IntoPortable for SignedExtensionMetadata {
 /// All metadata about an runtime pallet.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletMetadata<T: Form = MetaForm> {
@@ -178,9 +178,9 @@ impl IntoPortable for PalletMetadata {
 /// All metadata of the pallet's storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletStorageMetadata<T: Form = MetaForm> {
@@ -204,9 +204,9 @@ impl IntoPortable for PalletStorageMetadata {
 /// Metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
@@ -243,7 +243,7 @@ impl IntoPortable for StorageEntryMetadata {
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub enum StorageEntryModifier {
 	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
@@ -254,7 +254,7 @@ pub enum StorageEntryModifier {
 /// Hasher used by storage maps
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub enum StorageHasher {
 	/// 128-bit Blake2 hash.
 	Blake2_128,
@@ -275,9 +275,9 @@ pub enum StorageHasher {
 /// A type of storage value.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub enum StorageEntryType<T: Form = MetaForm> {
@@ -316,9 +316,9 @@ impl IntoPortable for StorageEntryType {
 /// Metadata for all calls in a pallet
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletCallMetadata<T: Form = MetaForm> {
@@ -345,7 +345,7 @@ impl From<MetaType> for PalletCallMetadata {
 /// Metadata about the pallet Event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
 	/// The Event type.
 	pub ty: T::Type,
@@ -370,9 +370,9 @@ impl From<MetaType> for PalletEventMetadata {
 /// Metadata about one pallet constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletConstantMetadata<T: Form = MetaForm> {
@@ -402,9 +402,9 @@ impl IntoPortable for PalletConstantMetadata {
 /// Metadata about a pallet error.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_codec", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
-	feature = "serde_codec",
+	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize"))
 )]
 pub struct PalletErrorMetadata<T: Form = MetaForm> {

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -15,12 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-cfg_if::cfg_if! {
-	if #[cfg(feature = "full_derive")] {
-		use codec::Decode;
-		use serde::Serialize;
-	}
-}
+#[cfg(feature = "decode")]
+use codec::Decode;
+#[cfg(feature = "serde_codec")]
+use serde::Serialize;
 
 use super::RuntimeMetadataPrefixed;
 use codec::Encode;
@@ -44,7 +42,8 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 
 /// The metadata of a runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 pub struct RuntimeMetadataV14 {
 	/// Type registry containing all types used in the metadata.
 	pub types: PortableRegistry,
@@ -78,9 +77,10 @@ impl RuntimeMetadataV14 {
 
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
@@ -106,9 +106,10 @@ impl IntoPortable for ExtrinsicMetadata {
 
 /// Metadata of an extrinsic's signed extension.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct SignedExtensionMetadata<T: Form = MetaForm> {
@@ -134,9 +135,10 @@ impl IntoPortable for SignedExtensionMetadata {
 
 /// All metadata about an runtime pallet.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletMetadata<T: Form = MetaForm> {
@@ -175,9 +177,10 @@ impl IntoPortable for PalletMetadata {
 
 /// All metadata of the pallet's storage.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletStorageMetadata<T: Form = MetaForm> {
@@ -200,9 +203,10 @@ impl IntoPortable for PalletStorageMetadata {
 
 /// Metadata about one storage entry.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct StorageEntryMetadata<T: Form = MetaForm> {
@@ -238,7 +242,8 @@ impl IntoPortable for StorageEntryMetadata {
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 pub enum StorageEntryModifier {
 	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
@@ -248,7 +253,8 @@ pub enum StorageEntryModifier {
 
 /// Hasher used by storage maps
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 pub enum StorageHasher {
 	/// 128-bit Blake2 hash.
 	Blake2_128,
@@ -268,9 +274,10 @@ pub enum StorageHasher {
 
 /// A type of storage value.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub enum StorageEntryType<T: Form = MetaForm> {
@@ -308,9 +315,10 @@ impl IntoPortable for StorageEntryType {
 
 /// Metadata for all calls in a pallet
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletCallMetadata<T: Form = MetaForm> {
@@ -336,7 +344,8 @@ impl From<MetaType> for PalletCallMetadata {
 
 /// Metadata about the pallet Event type.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
 	/// The Event type.
 	pub ty: T::Type,
@@ -360,9 +369,10 @@ impl From<MetaType> for PalletEventMetadata {
 
 /// Metadata about one pallet constant.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct PalletConstantMetadata<T: Form = MetaForm> {
@@ -391,9 +401,10 @@ impl IntoPortable for PalletConstantMetadata {
 
 /// Metadata about a pallet error.
 #[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "full_derive", derive(Decode, Serialize, Debug))]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_codec", derive(Serialize))]
 #[cfg_attr(
-	feature = "full_derive",
+	feature = "serde_codec",
 	serde(bound(serialize = "T::Type: Serialize"))
 )]
 pub struct PalletErrorMetadata<T: Form = MetaForm> {

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -41,7 +41,7 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 }
 
 /// The metadata of a runtime.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct RuntimeMetadataV14 {
@@ -76,7 +76,7 @@ impl RuntimeMetadataV14 {
 }
 
 /// Metadata of the extrinsic used by the runtime.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -105,7 +105,7 @@ impl IntoPortable for ExtrinsicMetadata {
 }
 
 /// Metadata of an extrinsic's signed extension.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -134,7 +134,7 @@ impl IntoPortable for SignedExtensionMetadata {
 }
 
 /// All metadata about an runtime pallet.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -176,7 +176,7 @@ impl IntoPortable for PalletMetadata {
 }
 
 /// All metadata of the pallet's storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -202,7 +202,7 @@ impl IntoPortable for PalletStorageMetadata {
 }
 
 /// Metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -241,7 +241,7 @@ impl IntoPortable for StorageEntryMetadata {
 ///
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub enum StorageEntryModifier {
@@ -252,7 +252,7 @@ pub enum StorageEntryModifier {
 }
 
 /// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub enum StorageHasher {
@@ -273,7 +273,7 @@ pub enum StorageHasher {
 }
 
 /// A type of storage value.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -314,7 +314,7 @@ impl IntoPortable for StorageEntryType {
 }
 
 /// Metadata for all calls in a pallet
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -343,7 +343,7 @@ impl From<MetaType> for PalletCallMetadata {
 }
 
 /// Metadata about the pallet Event type.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct PalletEventMetadata<T: Form = MetaForm> {
@@ -368,7 +368,7 @@ impl From<MetaType> for PalletEventMetadata {
 }
 
 /// Metadata about one pallet constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(
@@ -400,7 +400,7 @@ impl IntoPortable for PalletConstantMetadata {
 }
 
 /// Metadata about a pallet error.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -403,10 +403,7 @@ impl IntoPortable for PalletConstantMetadata {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(
-	feature = "serde_full",
-	serde(bound(serialize = "T::Type: Serialize"))
-)]
+#[cfg_attr(feature = "serde_full", serde(bound(serialize = "T::Type: Serialize")))]
 pub struct PalletErrorMetadata<T: Form = MetaForm> {
 	/// The error type information.
 	pub ty: T::Type,

--- a/frame-metadata/src/v8.rs
+++ b/frame-metadata/src/v8.rs
@@ -42,8 +42,8 @@ cfg_if::cfg_if! {
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
 	/// Function name.
 	pub name: DecodeDifferentStr,
@@ -54,8 +54,8 @@ pub struct FunctionMetadata {
 }
 
 /// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
 	/// Name of the variable for the argument.
 	pub name: DecodeDifferentStr,
@@ -64,8 +64,8 @@ pub struct FunctionArgumentMetadata {
 }
 
 /// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
 	/// Name of the event.
 	pub name: DecodeDifferentStr,
@@ -77,8 +77,8 @@ pub struct OuterEventMetadata {
 }
 
 /// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
 	/// Name of the event.
 	pub name: DecodeDifferentStr,
@@ -89,8 +89,8 @@ pub struct EventMetadata {
 }
 
 /// All the metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
 	/// Variable name of the storage entry.
 	pub name: DecodeDifferentStr,
@@ -105,8 +105,8 @@ pub struct StorageEntryMetadata {
 }
 
 /// All the metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
 	/// Name of the module constant.
 	pub name: DecodeDifferentStr,
@@ -119,8 +119,8 @@ pub struct ModuleConstantMetadata {
 }
 
 /// All the metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
 	/// Name of the error.
 	pub name: DecodeDifferentStr,
@@ -181,16 +181,15 @@ impl serde::Serialize for DefaultByteGetter {
 	}
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Debug for DefaultByteGetter {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for DefaultByteGetter {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
 		self.0.default_byte().fmt(f)
 	}
 }
 
 /// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageHasher {
 	/// 128-bit Blake2 hash.
 	Blake2_128,
@@ -205,8 +204,8 @@ pub enum StorageHasher {
 }
 
 /// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryType {
 	/// Plain storage entry (just the value).
 	Plain(DecodeDifferentStr),
@@ -240,8 +239,8 @@ pub enum StorageEntryType {
 ///
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
 	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
 	Optional,
@@ -250,8 +249,8 @@ pub enum StorageEntryModifier {
 }
 
 /// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
@@ -259,8 +258,8 @@ pub struct StorageMetadata {
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV8 {
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 }
@@ -269,8 +268,8 @@ pub struct RuntimeMetadataV8 {
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV8;
 
 /// All metadata about a runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleMetadata {
 	/// Module name.
 	pub name: DecodeDifferentStr,

--- a/frame-metadata/src/v9.rs
+++ b/frame-metadata/src/v9.rs
@@ -43,8 +43,8 @@ cfg_if::cfg_if! {
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// All the metadata about a function.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<FunctionArgumentMetadata>,
@@ -52,15 +52,15 @@ pub struct FunctionMetadata {
 }
 
 /// All the metadata about a function argument.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct FunctionArgumentMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
 }
 
 /// All the metadata about an outer event.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct OuterEventMetadata {
 	pub name: DecodeDifferentStr,
@@ -71,8 +71,8 @@ pub struct OuterEventMetadata {
 }
 
 /// All the metadata about an event.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct EventMetadata {
 	pub name: DecodeDifferentStr,
 	pub arguments: DecodeDifferentArray<&'static str, StringBuf>,
@@ -80,8 +80,8 @@ pub struct EventMetadata {
 }
 
 /// All the metadata about one storage entry.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageEntryMetadata {
 	pub name: DecodeDifferentStr,
 	pub modifier: StorageEntryModifier,
@@ -91,8 +91,8 @@ pub struct StorageEntryMetadata {
 }
 
 /// All the metadata about one module constant.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleConstantMetadata {
 	pub name: DecodeDifferentStr,
 	pub ty: DecodeDifferentStr,
@@ -101,8 +101,8 @@ pub struct ModuleConstantMetadata {
 }
 
 /// All the metadata about a module error.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ErrorMetadata {
 	pub name: DecodeDifferentStr,
 	pub documentation: DecodeDifferentArray<&'static str, StringBuf>,
@@ -166,8 +166,8 @@ impl core::fmt::Debug for DefaultByteGetter {
 }
 
 /// Hasher used by storage maps
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageHasher {
 	Blake2_128,
 	Blake2_256,
@@ -178,8 +178,8 @@ pub enum StorageHasher {
 }
 
 /// A storage entry type.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryType {
 	Plain(DecodeDifferentStr),
 	Map {
@@ -202,16 +202,16 @@ pub enum StorageEntryType {
 ///
 /// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
 /// `Default` means you should expect a `T` with the default value of default if the key is not present.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub enum StorageEntryModifier {
 	Optional,
 	Default,
 }
 
 /// All metadata of the storage.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
@@ -219,15 +219,15 @@ pub struct StorageMetadata {
 }
 
 /// The metadata of a runtime.
-#[derive(Eq, Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Eq, Encode, PartialEq, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct RuntimeMetadataV9 {
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 }
 
 /// All metadata about an runtime module.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Serialize, Debug))]
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "std", derive(Decode, Serialize))]
 pub struct ModuleMetadata {
 	pub name: DecodeDifferentStr,
 	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,


### PR DESCRIPTION
This PR is proposing upstreaming the work done by Integritee parachain and in particular @echevrier to make frame-metadata work for no_std. I have been using this fork myself for a month or two now and can confirm it works fine in browsers.

It's pretty important that we have no_std support as otherwise it's a big blocker for anyone trying to decode scale in wasm (ie. in the browser).

Happy to implement any feedback to get no_std support into main.

Co-authored-by: echevrier <edith.chevrier@scs.ch>