### PR TITLE
Add metadata V15 with Runtime API support

### DIFF
--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -19,7 +19,7 @@ scale-info = { version = "2.0.0", default-features = false, optional = true, fea
 serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
 
 [features]
-default = ["std", "v15"]
+default = ["std", "v14"]
 v8  = []
 v9  = []
 v10 = []
@@ -28,7 +28,7 @@ v12 = []
 v13 = []
 legacy = ["v13", "v12", "v11", "v10", "v9", "v8"]
 v14 = ["scale-info"]
-v15 = ["scale-info"]
+v15-unstable = ["scale-info"]
 
 # Serde support without relying on std features
 serde_full = [

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -19,7 +19,7 @@ scale-info = { version = "2.0.0", default-features = false, optional = true, fea
 serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
 
 [features]
-default = ["std", "v14"]
+default = ["std", "v15"]
 v8  = []
 v9  = []
 v10 = []
@@ -28,6 +28,7 @@ v12 = []
 v13 = []
 legacy = ["v13", "v12", "v11", "v10", "v9", "v8"]
 v14 = ["scale-info"]
+v15 = ["scale-info"]
 
 # Serde support without relying on std features
 serde_full = [

--- a/frame-metadata/src/decode_different.rs
+++ b/frame-metadata/src/decode_different.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -90,14 +90,14 @@ pub mod v13;
 pub mod v14;
 
 /// Metadata v15
-#[cfg(feature = "v15")]
+#[cfg(feature = "v15-unstable")]
 pub mod v15;
 
 // Reexport all the types from the latest version.
 //
 // When a new version becomes available, update this.
-#[cfg(feature = "v15")]
-pub use self::v15::*;
+#[cfg(feature = "v14")]
+pub use self::v14::*;
 
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq, Debug)]
@@ -177,10 +177,10 @@ pub enum RuntimeMetadata {
 	#[cfg(not(feature = "v14"))]
 	V14(OpaqueMetadata),
 	/// Version 15 for runtime metadata.
-	#[cfg(feature = "v15")]
+	#[cfg(feature = "v15-unstable")]
 	V15(v15::RuntimeMetadataV15),
 	/// Version 15 for runtime metadata, as raw encoded bytes.
-	#[cfg(not(feature = "v15"))]
+	#[cfg(not(feature = "v15-unstable"))]
 	V15(OpaqueMetadata),
 }
 

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -96,12 +96,6 @@ pub mod v15;
 // Reexport all the types from the latest version.
 //
 // When a new version becomes available, update this.
-#[cfg(feature = "v14")]
-pub use self::v14::*;
-
-// Reexport all the types from the latest version.
-//
-// When a new version becomes available, update this.
 #[cfg(feature = "v15")]
 pub use self::v15::*;
 

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -89,11 +89,15 @@ pub mod v13;
 #[cfg(feature = "v14")]
 pub mod v14;
 
+/// Metadata v15
+#[cfg(feature = "v15")]
+pub mod v15;
+
 // Reexport all the types from the latest version.
 //
 // When a new version becomes available, update this.
-#[cfg(feature = "v14")]
-pub use self::v14::*;
+#[cfg(feature = "v15")]
+pub use self::v15::*;
 
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq, Debug)]
@@ -172,6 +176,12 @@ pub enum RuntimeMetadata {
 	/// Version 14 for runtime metadata, as raw encoded bytes.
 	#[cfg(not(feature = "v14"))]
 	V14(OpaqueMetadata),
+	/// Version 15 for runtime metadata.
+	#[cfg(feature = "v15")]
+	V15(v15::RuntimeMetadataV15),
+	/// Version 15 for runtime metadata, as raw encoded bytes.
+	#[cfg(not(feature = "v15"))]
+	V15(OpaqueMetadata),
 }
 
 impl RuntimeMetadata {
@@ -193,6 +203,7 @@ impl RuntimeMetadata {
 			RuntimeMetadata::V12(_) => 12,
 			RuntimeMetadata::V13(_) => 13,
 			RuntimeMetadata::V14(_) => 14,
+			RuntimeMetadata::V15(_) => 15,
 		}
 	}
 }

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -96,6 +96,12 @@ pub mod v15;
 // Reexport all the types from the latest version.
 //
 // When a new version becomes available, update this.
+#[cfg(feature = "v14")]
+pub use self::v14::*;
+
+// Reexport all the types from the latest version.
+//
+// When a new version becomes available, update this.
 #[cfg(feature = "v15")]
 pub use self::v15::*;
 

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -100,7 +100,7 @@ pub mod v15;
 pub use self::v14::*;
 
 /// Metadata prefix.
-pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
+pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warning for endianness.
 
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq, Debug)]

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -99,6 +99,9 @@ pub mod v15;
 #[cfg(feature = "v14")]
 pub use self::v14::*;
 
+/// Metadata prefix.
+pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
+
 /// Metadata prefixed by a u32 for reserved usage
 #[derive(Eq, Encode, PartialEq, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]

--- a/frame-metadata/src/v10.rs
+++ b/frame-metadata/src/v10.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/v11.rs
+++ b/frame-metadata/src/v11.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/v12.rs
+++ b/frame-metadata/src/v12.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/v14.rs
+++ b/frame-metadata/src/v14.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -20,16 +20,13 @@ use codec::Decode;
 #[cfg(feature = "serde_full")]
 use serde::Serialize;
 
-use super::RuntimeMetadataPrefixed;
+use super::{RuntimeMetadataPrefixed, META_RESERVED};
 use codec::Encode;
 use scale_info::prelude::vec::Vec;
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	IntoPortable, MetaType, PortableRegistry, Registry,
 };
-
-/// Current prefix of metadata
-pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// Latest runtime metadata
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV15;
@@ -63,19 +60,19 @@ impl RuntimeMetadataV15 {
 		pallets: Vec<PalletMetadata>,
 		extrinsic: ExtrinsicMetadata,
 		runtime_type: MetaType,
-		runtime: Vec<RuntimeApiMetadata>,
+		apis: Vec<RuntimeApiMetadata>,
 	) -> Self {
 		let mut registry = Registry::new();
 		let pallets = registry.map_into_portable(pallets);
 		let extrinsic = extrinsic.into_portable(&mut registry);
 		let ty = registry.register_type(&runtime_type);
-		let runtime = registry.map_into_portable(runtime);
+		let apis = registry.map_into_portable(apis);
 		Self {
 			types: registry.into(),
 			pallets,
 			extrinsic,
 			ty,
-			runtime,
+			apis,
 		}
 	}
 }

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -95,6 +95,8 @@ pub struct TraitMetadata<T: Form = MetaForm> {
 	pub version: u64,
 	/// Trait methods.
 	pub methods: Vec<MethodMetadata<T>>,
+	/// Trait documentation.
+	pub docs: Vec<T::String>,
 }
 
 impl IntoPortable for TraitMetadata {
@@ -105,6 +107,7 @@ impl IntoPortable for TraitMetadata {
 			name: self.name.into_portable(registry),
 			version: self.version,
 			methods: registry.map_into_portable(self.methods),
+			docs: registry.map_into_portable(self.docs),
 		}
 	}
 }
@@ -124,6 +127,8 @@ pub struct MethodMetadata<T: Form = MetaForm> {
 	pub inputs: Vec<ParamMetadata<T>>,
 	/// Method output.
 	pub output: T::Type,
+	/// Method documentation.
+	pub docs: Vec<T::String>,
 }
 
 impl IntoPortable for MethodMetadata {
@@ -134,6 +139,7 @@ impl IntoPortable for MethodMetadata {
 			name: self.name.into_portable(registry),
 			inputs: registry.map_into_portable(self.inputs),
 			output: registry.register_type(&self.output),
+			docs: registry.map_into_portable(self.docs),
 		}
 	}
 }

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -89,7 +89,7 @@ pub struct TraitMetadata<T: Form = MetaForm> {
 	/// Trait version.
 	pub version: u64,
 	/// Trait methods.
-	pub methods: Vec<T::String>,
+	pub methods: Vec<MethodMetadata<T>>,
 }
 
 impl IntoPortable for TraitMetadata {
@@ -116,7 +116,7 @@ pub struct MethodMetadata<T: Form = MetaForm> {
 	/// Method name.
 	pub name: T::String,
 	/// Method parameters.
-	pub inputs: Vec<T::String>,
+	pub inputs: Vec<ParamMetadata<T>>,
 	/// Method output.
 	pub output: T::Type,
 }
@@ -129,6 +129,32 @@ impl IntoPortable for MethodMetadata {
 			name: self.name.into_portable(registry),
 			inputs: registry.map_into_portable(self.inputs),
 			output: registry.register_type(&self.output),
+		}
+	}
+}
+
+/// Metadata of a runtime method parameter.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct ParamMetadata<T: Form = MetaForm> {
+	/// Parameter name.
+	pub name: T::String,
+	/// Parameter type.
+	pub ty: T::Type,
+}
+
+impl IntoPortable for ParamMetadata {
+	type Output = ParamMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		ParamMetadata {
+			name: self.name.into_portable(registry),
+			ty: registry.register_type(&self.ty),
 		}
 	}
 }

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -121,7 +121,7 @@ pub struct RuntimeApiMethodMetadata<T: Form = MetaForm> {
 	/// Method name.
 	pub name: T::String,
 	/// Method parameters.
-	pub inputs: Vec<ParamMetadata<T>>,
+	pub inputs: Vec<RuntimeApiMethodParamMetadata<T>>,
 	/// Method output.
 	pub output: T::Type,
 	/// Method documentation.
@@ -149,18 +149,18 @@ impl IntoPortable for RuntimeApiMethodMetadata {
 	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct ParamMetadata<T: Form = MetaForm> {
+pub struct RuntimeApiMethodParamMetadata<T: Form = MetaForm> {
 	/// Parameter name.
 	pub name: T::String,
 	/// Parameter type.
 	pub ty: T::Type,
 }
 
-impl IntoPortable for ParamMetadata {
-	type Output = ParamMetadata<PortableForm>;
+impl IntoPortable for RuntimeApiMethodParamMetadata {
+	type Output = RuntimeApiMethodParamMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		ParamMetadata {
+		RuntimeApiMethodParamMetadata {
 			name: self.name.into_portable(registry),
 			ty: registry.register_type(&self.ty),
 		}

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -1,0 +1,426 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "decode")]
+use codec::Decode;
+#[cfg(feature = "serde_full")]
+use serde::Serialize;
+
+use super::RuntimeMetadataPrefixed;
+use codec::Encode;
+use scale_info::prelude::vec::Vec;
+use scale_info::{
+	form::{Form, MetaForm, PortableForm},
+	IntoPortable, MetaType, PortableRegistry, Registry,
+};
+
+/// Current prefix of metadata
+pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
+
+/// Latest runtime metadata
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV14;
+
+impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
+	fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
+		RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V14(metadata))
+	}
+}
+
+/// The metadata of a runtime.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+pub struct RuntimeMetadataV14 {
+	/// Type registry containing all types used in the metadata.
+	pub types: PortableRegistry,
+	/// Metadata of all the pallets.
+	pub pallets: Vec<PalletMetadata<PortableForm>>,
+	/// Metadata of the extrinsic.
+	pub extrinsic: ExtrinsicMetadata<PortableForm>,
+	/// The type of the `Runtime`.
+	pub ty: <PortableForm as Form>::Type,
+}
+
+impl RuntimeMetadataV14 {
+	/// Create a new instance of [`RuntimeMetadataV14`].
+	pub fn new(
+		pallets: Vec<PalletMetadata>,
+		extrinsic: ExtrinsicMetadata,
+		runtime_type: MetaType,
+	) -> Self {
+		let mut registry = Registry::new();
+		let pallets = registry.map_into_portable(pallets);
+		let extrinsic = extrinsic.into_portable(&mut registry);
+		let ty = registry.register_type(&runtime_type);
+		Self {
+			types: registry.into(),
+			pallets,
+			extrinsic,
+			ty,
+		}
+	}
+}
+
+/// Metadata of the extrinsic used by the runtime.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct ExtrinsicMetadata<T: Form = MetaForm> {
+	/// The type of the extrinsic.
+	pub ty: T::Type,
+	/// Extrinsic version.
+	pub version: u8,
+	/// The signed extensions in the order they appear in the extrinsic.
+	pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
+}
+
+impl IntoPortable for ExtrinsicMetadata {
+	type Output = ExtrinsicMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		ExtrinsicMetadata {
+			ty: registry.register_type(&self.ty),
+			version: self.version,
+			signed_extensions: registry.map_into_portable(self.signed_extensions),
+		}
+	}
+}
+
+/// Metadata of an extrinsic's signed extension.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct SignedExtensionMetadata<T: Form = MetaForm> {
+	/// The unique signed extension identifier, which may be different from the type name.
+	pub identifier: T::String,
+	/// The type of the signed extension, with the data to be included in the extrinsic.
+	pub ty: T::Type,
+	/// The type of the additional signed data, with the data to be included in the signed payload
+	pub additional_signed: T::Type,
+}
+
+impl IntoPortable for SignedExtensionMetadata {
+	type Output = SignedExtensionMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		SignedExtensionMetadata {
+			identifier: self.identifier.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+			additional_signed: registry.register_type(&self.additional_signed),
+		}
+	}
+}
+
+/// All metadata about an runtime pallet.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletMetadata<T: Form = MetaForm> {
+	/// Pallet name.
+	pub name: T::String,
+	/// Pallet storage metadata.
+	pub storage: Option<PalletStorageMetadata<T>>,
+	/// Pallet calls metadata.
+	pub calls: Option<PalletCallMetadata<T>>,
+	/// Pallet event metadata.
+	pub event: Option<PalletEventMetadata<T>>,
+	/// Pallet constants metadata.
+	pub constants: Vec<PalletConstantMetadata<T>>,
+	/// Pallet error metadata.
+	pub error: Option<PalletErrorMetadata<T>>,
+	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
+	/// call and origin variants.
+	pub index: u8,
+}
+
+impl IntoPortable for PalletMetadata {
+	type Output = PalletMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletMetadata {
+			name: self.name.into_portable(registry),
+			storage: self.storage.map(|storage| storage.into_portable(registry)),
+			calls: self.calls.map(|calls| calls.into_portable(registry)),
+			event: self.event.map(|event| event.into_portable(registry)),
+			constants: registry.map_into_portable(self.constants),
+			error: self.error.map(|error| error.into_portable(registry)),
+			index: self.index,
+		}
+	}
+}
+
+/// All metadata of the pallet's storage.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletStorageMetadata<T: Form = MetaForm> {
+	/// The common prefix used by all storage entries.
+	pub prefix: T::String,
+	/// Metadata for all storage entries.
+	pub entries: Vec<StorageEntryMetadata<T>>,
+}
+
+impl IntoPortable for PalletStorageMetadata {
+	type Output = PalletStorageMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletStorageMetadata {
+			prefix: self.prefix.into_portable(registry),
+			entries: registry.map_into_portable(self.entries),
+		}
+	}
+}
+
+/// Metadata about one storage entry.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct StorageEntryMetadata<T: Form = MetaForm> {
+	/// Variable name of the storage entry.
+	pub name: T::String,
+	/// An `Option` modifier of that storage entry.
+	pub modifier: StorageEntryModifier,
+	/// Type of the value stored in the entry.
+	pub ty: StorageEntryType<T>,
+	/// Default value (SCALE encoded).
+	pub default: Vec<u8>,
+	/// Storage entry documentation.
+	pub docs: Vec<T::String>,
+}
+
+impl IntoPortable for StorageEntryMetadata {
+	type Output = StorageEntryMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		StorageEntryMetadata {
+			name: self.name.into_portable(registry),
+			modifier: self.modifier,
+			ty: self.ty.into_portable(registry),
+			default: self.default,
+			docs: registry.map_into_portable(self.docs),
+		}
+	}
+}
+
+/// A storage entry modifier indicates how a storage entry is returned when fetched and what the value will be if the key is not present.
+/// Specifically this refers to the "return type" when fetching a storage entry, and what the value will be if the key is not present.
+///
+/// `Optional` means you should expect an `Option<T>`, with `None` returned if the key is not present.
+/// `Default` means you should expect a `T` with the default value of default if the key is not present.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+pub enum StorageEntryModifier {
+	/// The storage entry returns an `Option<T>`, with `None` if the key is not present.
+	Optional,
+	/// The storage entry returns `T::Default` if the key is not present.
+	Default,
+}
+
+/// Hasher used by storage maps
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+pub enum StorageHasher {
+	/// 128-bit Blake2 hash.
+	Blake2_128,
+	/// 256-bit Blake2 hash.
+	Blake2_256,
+	/// Multiple 128-bit Blake2 hashes concatenated.
+	Blake2_128Concat,
+	/// 128-bit XX hash.
+	Twox128,
+	/// 256-bit XX hash.
+	Twox256,
+	/// Multiple 64-bit XX hashes concatenated.
+	Twox64Concat,
+	/// Identity hashing (no hashing).
+	Identity,
+}
+
+/// A type of storage value.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub enum StorageEntryType<T: Form = MetaForm> {
+	/// Plain storage entry (just the value).
+	Plain(T::Type),
+	/// A storage map.
+	Map {
+		/// One or more hashers, should be one hasher per key element.
+		hashers: Vec<StorageHasher>,
+		/// The type of the key, can be a tuple with elements for each of the hashers.
+		key: T::Type,
+		/// The type of the value.
+		value: T::Type,
+	},
+}
+
+impl IntoPortable for StorageEntryType {
+	type Output = StorageEntryType<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		match self {
+			Self::Plain(plain) => StorageEntryType::Plain(registry.register_type(&plain)),
+			Self::Map {
+				hashers,
+				key,
+				value,
+			} => StorageEntryType::Map {
+				hashers,
+				key: registry.register_type(&key),
+				value: registry.register_type(&value),
+			},
+		}
+	}
+}
+
+/// Metadata for all calls in a pallet
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletCallMetadata<T: Form = MetaForm> {
+	/// The corresponding enum type for the pallet call.
+	pub ty: T::Type,
+}
+
+impl IntoPortable for PalletCallMetadata {
+	type Output = PalletCallMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletCallMetadata {
+			ty: registry.register_type(&self.ty),
+		}
+	}
+}
+
+impl From<MetaType> for PalletCallMetadata {
+	fn from(ty: MetaType) -> Self {
+		Self { ty }
+	}
+}
+
+/// Metadata about the pallet Event type.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+pub struct PalletEventMetadata<T: Form = MetaForm> {
+	/// The Event type.
+	pub ty: T::Type,
+}
+
+impl IntoPortable for PalletEventMetadata {
+	type Output = PalletEventMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletEventMetadata {
+			ty: registry.register_type(&self.ty),
+		}
+	}
+}
+
+impl From<MetaType> for PalletEventMetadata {
+	fn from(ty: MetaType) -> Self {
+		Self { ty }
+	}
+}
+
+/// Metadata about one pallet constant.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct PalletConstantMetadata<T: Form = MetaForm> {
+	/// Name of the pallet constant.
+	pub name: T::String,
+	/// Type of the pallet constant.
+	pub ty: T::Type,
+	/// Value stored in the constant (SCALE encoded).
+	pub value: Vec<u8>,
+	/// Documentation of the constant.
+	pub docs: Vec<T::String>,
+}
+
+impl IntoPortable for PalletConstantMetadata {
+	type Output = PalletConstantMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletConstantMetadata {
+			name: self.name.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+			value: self.value,
+			docs: registry.map_into_portable(self.docs),
+		}
+	}
+}
+
+/// Metadata about a pallet error.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", serde(bound(serialize = "T::Type: Serialize")))]
+pub struct PalletErrorMetadata<T: Form = MetaForm> {
+	/// The error type information.
+	pub ty: T::Type,
+}
+
+impl IntoPortable for PalletErrorMetadata {
+	type Output = PalletErrorMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletErrorMetadata {
+			ty: registry.register_type(&self.ty),
+		}
+	}
+}
+
+impl From<MetaType> for PalletErrorMetadata {
+	fn from(ty: MetaType) -> Self {
+		Self { ty }
+	}
+}

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -54,7 +54,7 @@ pub struct RuntimeMetadataV15 {
 	/// The type of the `Runtime`.
 	pub ty: <PortableForm as Form>::Type,
 	/// Metadata of the Runtime API.
-	pub runtime: Vec<TraitMetadata<PortableForm>>,
+	pub runtime: Vec<RuntimeApiMetadata<PortableForm>>,
 }
 
 impl RuntimeMetadataV15 {
@@ -63,7 +63,7 @@ impl RuntimeMetadataV15 {
 		pallets: Vec<PalletMetadata>,
 		extrinsic: ExtrinsicMetadata,
 		runtime_type: MetaType,
-		runtime: Vec<TraitMetadata>,
+		runtime: Vec<RuntimeApiMetadata>,
 	) -> Self {
 		let mut registry = Registry::new();
 		let pallets = registry.map_into_portable(pallets);
@@ -88,20 +88,20 @@ impl RuntimeMetadataV15 {
 	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct TraitMetadata<T: Form = MetaForm> {
+pub struct RuntimeApiMetadata<T: Form = MetaForm> {
 	/// Trait name.
 	pub name: T::String,
 	/// Trait methods.
-	pub methods: Vec<MethodMetadata<T>>,
+	pub methods: Vec<RuntimeApiMethodMetadata<T>>,
 	/// Trait documentation.
 	pub docs: Vec<T::String>,
 }
 
-impl IntoPortable for TraitMetadata {
-	type Output = TraitMetadata<PortableForm>;
+impl IntoPortable for RuntimeApiMetadata {
+	type Output = RuntimeApiMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		TraitMetadata {
+		RuntimeApiMetadata {
 			name: self.name.into_portable(registry),
 			methods: registry.map_into_portable(self.methods),
 			docs: registry.map_into_portable(self.docs),
@@ -117,7 +117,7 @@ impl IntoPortable for TraitMetadata {
 	feature = "serde_full",
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
-pub struct MethodMetadata<T: Form = MetaForm> {
+pub struct RuntimeApiMethodMetadata<T: Form = MetaForm> {
 	/// Method name.
 	pub name: T::String,
 	/// Method parameters.
@@ -128,11 +128,11 @@ pub struct MethodMetadata<T: Form = MetaForm> {
 	pub docs: Vec<T::String>,
 }
 
-impl IntoPortable for MethodMetadata {
-	type Output = MethodMetadata<PortableForm>;
+impl IntoPortable for RuntimeApiMethodMetadata {
+	type Output = RuntimeApiMethodMetadata<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		MethodMetadata {
+		RuntimeApiMethodMetadata {
 			name: self.name.into_portable(registry),
 			inputs: registry.map_into_portable(self.inputs),
 			output: registry.register_type(&self.output),

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -91,8 +91,6 @@ impl RuntimeMetadataV15 {
 pub struct TraitMetadata<T: Form = MetaForm> {
 	/// Trait name.
 	pub name: T::String,
-	/// Trait version.
-	pub version: Option<u64>,
 	/// Trait methods.
 	pub methods: Vec<MethodMetadata<T>>,
 	/// Trait documentation.
@@ -105,7 +103,6 @@ impl IntoPortable for TraitMetadata {
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		TraitMetadata {
 			name: self.name.into_portable(registry),
-			version: self.version,
 			methods: registry.map_into_portable(self.methods),
 			docs: registry.map_into_portable(self.docs),
 		}

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -53,6 +53,8 @@ pub struct RuntimeMetadataV15 {
 	pub extrinsic: ExtrinsicMetadata<PortableForm>,
 	/// The type of the `Runtime`.
 	pub ty: <PortableForm as Form>::Type,
+	/// Metadata of the Runtime API.
+	pub runtime: Vec<TraitMetadata<PortableForm>>,
 }
 
 impl RuntimeMetadataV15 {
@@ -61,16 +63,19 @@ impl RuntimeMetadataV15 {
 		pallets: Vec<PalletMetadata>,
 		extrinsic: ExtrinsicMetadata,
 		runtime_type: MetaType,
+		runtime: Vec<TraitMetadata>,
 	) -> Self {
 		let mut registry = Registry::new();
 		let pallets = registry.map_into_portable(pallets);
 		let extrinsic = extrinsic.into_portable(&mut registry);
 		let ty = registry.register_type(&runtime_type);
+		let runtime = registry.map_into_portable(runtime);
 		Self {
 			types: registry.into(),
 			pallets,
 			extrinsic,
 			ty,
+			runtime,
 		}
 	}
 }

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -249,6 +249,8 @@ pub struct PalletMetadata<T: Form = MetaForm> {
 	/// Define the index of the pallet, this index will be used for the encoding of pallet event,
 	/// call and origin variants.
 	pub index: u8,
+	/// Pallet documentation.
+	pub docs: Vec<T::String>,
 }
 
 impl IntoPortable for PalletMetadata {
@@ -263,6 +265,7 @@ impl IntoPortable for PalletMetadata {
 			constants: registry.map_into_portable(self.constants),
 			error: self.error.map(|error| error.into_portable(registry)),
 			index: self.index,
+			docs: registry.map_into_portable(self.docs),
 		}
 	}
 }

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -104,6 +104,35 @@ impl IntoPortable for TraitMetadata {
 	}
 }
 
+/// Metadata of a runtime method.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct MethodMetadata<T: Form = MetaForm> {
+	/// Method name.
+	pub name: T::String,
+	/// Method parameters.
+	pub inputs: Vec<T::String>,
+	/// Method output.
+	pub output: T::Type,
+}
+
+impl IntoPortable for MethodMetadata {
+	type Output = MethodMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		MethodMetadata {
+			name: self.name.into_portable(registry),
+			inputs: registry.map_into_portable(self.inputs),
+			output: registry.register_type(&self.output),
+		}
+	}
+}
+
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -92,7 +92,7 @@ pub struct TraitMetadata<T: Form = MetaForm> {
 	/// Trait name.
 	pub name: T::String,
 	/// Trait version.
-	pub version: u64,
+	pub version: Option<u64>,
 	/// Trait methods.
 	pub methods: Vec<MethodMetadata<T>>,
 	/// Trait documentation.

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -32,11 +32,11 @@ use scale_info::{
 pub const META_RESERVED: u32 = 0x6174656d; // 'meta' warn endianness
 
 /// Latest runtime metadata
-pub type RuntimeMetadataLastVersion = RuntimeMetadataV14;
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV15;
 
 impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 	fn from(metadata: RuntimeMetadataLastVersion) -> RuntimeMetadataPrefixed {
-		RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V14(metadata))
+		RuntimeMetadataPrefixed(META_RESERVED, super::RuntimeMetadata::V15(metadata))
 	}
 }
 
@@ -44,7 +44,7 @@ impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
-pub struct RuntimeMetadataV14 {
+pub struct RuntimeMetadataV15 {
 	/// Type registry containing all types used in the metadata.
 	pub types: PortableRegistry,
 	/// Metadata of all the pallets.
@@ -55,8 +55,8 @@ pub struct RuntimeMetadataV14 {
 	pub ty: <PortableForm as Form>::Type,
 }
 
-impl RuntimeMetadataV14 {
-	/// Create a new instance of [`RuntimeMetadataV14`].
+impl RuntimeMetadataV15 {
+	/// Create a new instance of [`RuntimeMetadataV15`].
 	pub fn new(
 		pallets: Vec<PalletMetadata>,
 		extrinsic: ExtrinsicMetadata,

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -54,7 +54,7 @@ pub struct RuntimeMetadataV15 {
 	/// The type of the `Runtime`.
 	pub ty: <PortableForm as Form>::Type,
 	/// Metadata of the Runtime API.
-	pub runtime: Vec<RuntimeApiMetadata<PortableForm>>,
+	pub apis: Vec<RuntimeApiMetadata<PortableForm>>,
 }
 
 impl RuntimeMetadataV15 {

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -75,6 +75,35 @@ impl RuntimeMetadataV15 {
 	}
 }
 
+/// Metadata of a runtime trait.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(
+	feature = "serde_full",
+	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
+)]
+pub struct TraitMetadata<T: Form = MetaForm> {
+	/// Trait name.
+	pub name: T::String,
+	/// Trait version.
+	pub version: u64,
+	/// Trait methods.
+	pub methods: Vec<T::String>,
+}
+
+impl IntoPortable for TraitMetadata {
+	type Output = TraitMetadata<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		TraitMetadata {
+			name: self.name.into_portable(registry),
+			version: self.version,
+			methods: registry.map_into_portable(self.methods),
+		}
+	}
+}
+
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]

--- a/frame-metadata/src/v8.rs
+++ b/frame-metadata/src/v8.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame-metadata/src/v9.rs
+++ b/frame-metadata/src/v9.rs
@@ -1,6 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2018-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The v15 metadata extends the v14 with the `runtime` field. This field (similarly to the `pallets` field) contains all the information needed to generate an API in higher-level projects (subxt, capi etc).

The runtime field is a collection of `TraitMetadata` objects that contain: 
- trait name
- optionally a trait version
- methods available:
   - method name
   - method inputs (name and meta::Type - ie `bytes: &[u8]`)
   - method output (meta::Type)
   - documentation
- documentation (that is only visible at `decl_runtime_apis` and valuable for UX)

While the metadata v15 might not yet be in its final form, this PR focus on adding support for the Runtime while allowing users (Substrate) to still utilize the v14.

The metadata v15 also includes the documentation of pallets needed by https://github.com/paritytech/frame-metadata/issues/47 and introduced in substrate via https://github.com/paritytech/substrate/pull/13452.

More details: https://github.com/paritytech/substrate/issues/12939#issuecomment-1400232374.

Part of https://github.com/paritytech/substrate/issues/12939

cc @paritytech/tools-team