### PR TITLE
chore: Enable rust tests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
     paths-ignore:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,4 +172,4 @@ jobs:
         run: cargo hack check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4
 
       - name: Checking feature combinations excluding decode/serde_full (native)
-        run: check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4
+        run: cargo hack check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,6 +124,7 @@ jobs:
             profile: minimal
             toolchain: stable
             components: clippy
+            target: wasm32-unknown-unknown
             override: true
 
       - name: Rust Cache
@@ -134,9 +135,6 @@ jobs:
         with:
           crate: cargo-hack
           version: 0.5
-
-      - name: Add WASM Utilities
-        run: rustup target add wasm32-unknown-unknown --toolchain stable
 
       - name: Checking wasm32 (v14)
         run: cargo hack check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4 --target wasm32-unknown-unknown

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
       - v*
     paths-ignore:
       - 'README.md'
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
 
   check-test-build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name:                              Compilation and Testing Suite
+name: Compilation and Testing Suite
 
 on:
   pull_request:
@@ -14,107 +14,162 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-
-  check-test-build:
-    name:                          Check, test and build
-    runs-on:                       ubuntu-latest
-    env:
-      RUST_BACKTRACE:              full
+  fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-latest
     steps:
-      - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
-        with:
-          access_token:            ${{ github.token }}
-      - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@v3
-        with:
-          fetch-depth:             5
-          submodules:              recursive
-## Check Stage
-      - name:                      Checking rust-stable
-        uses:                      actions-rs/cargo@v1
-        with:
-          command:                 check
-          toolchain:               stable
-          args:                    --all  --verbose
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-## Test Stage
-      - name:                      Testing rust-stable
-        uses:                      actions-rs/cargo@v1
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command:                 test
-          toolchain:               stable
-          args:                    --all  --verbose
+            profile: minimal
+            toolchain: nightly
+            override: true
+            components: rustfmt
 
-## Build Stage
-      - name:                      Building rust-stable
-        uses:                      actions-rs/cargo@v1
-        if:                        github.ref == 'refs/heads/master'
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+
+      - name: Cargo fmt
+        uses: actions-rs/cargo@v1.0.3
         with:
-          command:                 build
-          toolchain:               stable
-          args:                    --all --verbose
+          command: fmt
+          args: --all -- --check
+
+  docs:
+    name: Check documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+
+      - name: Check internal documentation links
+        run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc -vv --workspace --no-deps --document-private-items
+
+      - name: Run cargo test on documentation
+        uses: actions-rs/cargo@v1.0.3
+        with:
+            command: test
+            args: --doc
+
+  tests:
+    name: Cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+
+      - name: Cargo test
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --all-targets --workspace
+
+  clippy:
+    name: Cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+            components: clippy
+            override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets -- -D warnings
 
   check-wasm:
-    name:                          Check WASM
-    runs-on:                       ubuntu-latest
-    env:
-      RUST_BACKTRACE:              full
+    name: Check WASM
+    runs-on: ubuntu-latest
     steps:
-      - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          access_token:            ${{ github.token }}
-      - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@v3
+            profile: minimal
+            toolchain: stable
+            components: clippy
+            override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v1
         with:
-          fetch-depth:             5
-          submodules:              recursive
-      - name:                      Add WASM Utilities
-        run:                       rustup target add wasm32-unknown-unknown --toolchain stable
-## Check Stage
-      - name:                      Checking wasm32 (v14)
-        uses:                      actions-rs/cargo@v1
-        uses:                      taiki-e/install-action@cargo-hack
-        with:
-          command:                 hack
-          toolchain:               stable
-          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4 --target wasm32-unknown-unknown
-      - name:                      Checking wasm32 (all features)
-        uses:                      actions-rs/cargo@v1
-        uses:                      taiki-e/install-action@cargo-hack
-        with:
-          command:                 hack
-          toolchain:               stable
-          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4 --target wasm32-unknown-unknown
+          crate: cargo-hack
+          version: 0.5
+
+      - name: Add WASM Utilities
+        run: rustup target add wasm32-unknown-unknown --toolchain stable
+
+      - name: Checking wasm32 (v14)
+        run: cargo hack check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4 --target wasm32-unknown-unknown
+
+      - name: Checking wasm32 (all features)
+        run: cargo hack check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4 --target wasm32-unknown-unknown
 
   check-features:
-    name:                          Check Features
-    runs-on:                       ubuntu-latest
-    env:
-      RUST_BACKTRACE:              full
+    name: Check Features
+    runs-on: ubuntu-latest
     steps:
-      - name:                      Cancel Previous Runs
-        uses:                      styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # 0.11.0
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          access_token:            ${{ github.token }}
-      - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@v3
+            profile: minimal
+            toolchain: stable
+            components: clippy
+            override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v1
         with:
-          fetch-depth:             5
-          submodules:              recursive
-## Check Stage
-      - name:                      Checking v14 feature combinations (native)
-        uses:                      actions-rs/cargo@v1
-        uses:                      taiki-e/install-action@cargo-hack
-        with:
-          command:                 hack
-          toolchain:               stable
-          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4
-      - name:                      Checking feature combinations excluding decode/serde_full (native)
-        uses:                      actions-rs/cargo@v1
-        uses:                      taiki-e/install-action@cargo-hack
-        with:
-          command:                 hack
-          toolchain:               stable
-          args:                    check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4
+          crate: cargo-hack
+          version: 0.5
+
+      - name: Checking v14 feature combinations (native)
+        run: cargo hack check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --features v14 --skip legacy,v8,v9,v10,v11,v12,v13 --depth 4
+
+      - name: Checking feature combinations excluding decode/serde_full (native)
+        run: check --manifest-path ./frame-metadata/Cargo.toml --feature-powerset --no-dev-deps --skip decode,serde_full --depth 4

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -101,9 +101,9 @@ pub use self::v14::*;
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 pub struct RuntimeMetadataPrefixed(pub u32, pub RuntimeMetadata);
 
-impl Into<Vec<u8>> for RuntimeMetadataPrefixed {
-	fn into(self) -> Vec<u8> {
-		self.encode()
+impl From<RuntimeMetadataPrefixed> for Vec<u8> {
+	fn from(value: RuntimeMetadataPrefixed) -> Self {
+		value.encode()
 	}
 }
 


### PR DESCRIPTION
This PR re-enables the github CI that was not running due to

```bash
 Invalid workflow file: .github/workflows/rust.yml#L74
The workflow is not valid. .github/workflows/rust.yml (Line: 74, Col: 9): 'uses' is already defined .github/workflows/rust.yml (Line: 81, Col: 9): 'uses' is already defined
```

While at it, add some extra checks for documentation, style and tests. 

// CC: @paritytech/tools-team 