### PR TITLE
Metadata V15: Enrich extrinsic type info for decoding

### DIFF
--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -171,10 +171,12 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
-	/// The type of the extrinsic.
-	pub ty: T::Type,
 	/// Extrinsic version.
 	pub version: u8,
+	/// The prefix of the extrinsic.
+	///
+	/// This is the type of the encoded length of this extrinsic.
+	pub len_ty: T::Type,
 	/// The type of the address that signes the extrinsic
 	pub address_ty: T::Type,
 	/// The type of the outermost Call enum.
@@ -192,8 +194,8 @@ impl IntoPortable for ExtrinsicMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
-			ty: registry.register_type(&self.ty),
 			version: self.version,
+			len_ty: registry.register_type(&self.len_ty),
 			address_ty: registry.register_type(&self.address_ty),
 			call_ty: registry.register_type(&self.call_ty),
 			signature_ty: registry.register_type(&self.signature_ty),

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -175,6 +175,12 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	pub ty: T::Type,
 	/// Extrinsic version.
 	pub version: u8,
+	/// The type of the address that signes the extrinsic
+	pub address_ty: T::Type,
+	/// The type of the call.
+	pub call_ty: T::Type,
+	/// The type of the extrinsic's signature.
+	pub signature_ty: T::Type,
 	/// The signed extensions in the order they appear in the extrinsic.
 	pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
 }

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -177,10 +177,12 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	pub version: u8,
 	/// The type of the address that signes the extrinsic
 	pub address_ty: T::Type,
-	/// The type of the call.
+	/// The type of the outermost Call enum.
 	pub call_ty: T::Type,
 	/// The type of the extrinsic's signature.
 	pub signature_ty: T::Type,
+	/// The type of the outermost Extra enum.
+	pub extra_ty: T::Type,
 	/// The signed extensions in the order they appear in the extrinsic.
 	pub signed_extensions: Vec<SignedExtensionMetadata<T>>,
 }
@@ -192,6 +194,10 @@ impl IntoPortable for ExtrinsicMetadata {
 		ExtrinsicMetadata {
 			ty: registry.register_type(&self.ty),
 			version: self.version,
+			address_ty: registry.register_type(&self.address_ty),
+			call_ty: registry.register_type(&self.call_ty),
+			signature_ty: registry.register_type(&self.signature_ty),
+			extra_ty: registry.register_type(&self.extra_ty),
 			signed_extensions: registry.map_into_portable(self.signed_extensions),
 		}
 	}

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -173,10 +173,6 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// Extrinsic version.
 	pub version: u8,
-	/// The prefix of the extrinsic.
-	///
-	/// This is the type of the encoded length of this extrinsic.
-	pub len_ty: T::Type,
 	/// The type of the address that signes the extrinsic
 	pub address_ty: T::Type,
 	/// The type of the outermost Call enum.
@@ -195,7 +191,6 @@ impl IntoPortable for ExtrinsicMetadata {
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
 			version: self.version,
-			len_ty: registry.register_type(&self.len_ty),
 			address_ty: registry.register_type(&self.address_ty),
 			call_ty: registry.register_type(&self.call_ty),
 			signature_ty: registry.register_type(&self.signature_ty),


### PR DESCRIPTION
Metadata is enriched to provide users with additional types for decoding extrinsics:
- Address type
 - Call type
 - Signature type
 - Extra type

For more info visit: https://github.com/paritytech/substrate/pull/14123

// CC @paritytech/subxt-team 