### PR TITLE
v15: Rename `error_enum_ty` to `module_error_enum_ty`

### DIFF
--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -57,10 +57,10 @@ pub struct RuntimeMetadataV15 {
 	/// The module error type of the
 	/// [`DispatchError::Module`](https://docs.rs/sp-runtime/24.0.0/sp_runtime/enum.DispatchError.html#variant.Module) variant.
 	///
-	/// The `Module` variant will be 5 scale encoded bytes which are normally decoded into 
+	/// The `Module` variant will be 5 scale encoded bytes which are normally decoded into
 	/// an `{ index: u8, error: [u8; 4] }` struct. This type ID points to an enum type which instead
-	/// interprets the first `index` byte as a pallet variant, and the remaining `error` bytes as the 
-	/// appropriate `pallet::Error` type. It is an equally valid way to decode the error bytes, and 
+	/// interprets the first `index` byte as a pallet variant, and the remaining `error` bytes as the
+	/// appropriate `pallet::Error` type. It is an equally valid way to decode the error bytes, and
 	/// can be more informative.
 	///
 	/// # Note

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -57,8 +57,11 @@ pub struct RuntimeMetadataV15 {
 	/// The module error type of the
 	/// [`DispatchError::Module`](https://docs.rs/sp-runtime/24.0.0/sp_runtime/enum.DispatchError.html#variant.Module) variant.
 	///
-	/// This provides useful information for decoding the `ModuleError` and has a similar
-	/// shape with `call_enum_ty` and `event_enum_ty`.
+	/// The `Module` variant will be 5 scale encoded bytes which are normally decoded into 
+	/// an `{ index: u8, error: [u8; 4] }` struct. This type ID points to an enum type which instead
+	/// interprets the first `index` byte as a pallet variant, and the remaining `error` bytes as the 
+	/// appropriate `pallet::Error` type. It is an equally valid way to decode the error bytes, and 
+	/// can be more informative.
 	///
 	/// # Note
 	///

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -54,8 +54,17 @@ pub struct RuntimeMetadataV15 {
 	pub call_enum_ty: <PortableForm as Form>::Type,
 	/// The type of the outer `RuntimeEvent` enum.
 	pub event_enum_ty: <PortableForm as Form>::Type,
-	/// The type of the outer `RuntimeError` enum.
-	pub error_enum_ty: <PortableForm as Form>::Type,
+	/// The module error type of the
+	/// [`DispatchError::Module`](https://docs.rs/sp-runtime/24.0.0/sp_runtime/enum.DispatchError.html#variant.Module) variant.
+	///
+	/// This provides useful information for decoding the `ModuleError` and has a similar
+	/// shape with `call_enum_ty` and `event_enum_ty`.
+	///
+	/// # Note
+	///
+	/// This type cannot be used directly to decode `sp_runtime::DispatchError` from the
+	/// chain. It provides just the information needed to decode `sp_runtime::DispatchError::Module`.
+	pub module_error_enum_ty: <PortableForm as Form>::Type,
 }
 
 impl RuntimeMetadataV15 {

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -65,8 +65,10 @@ pub struct RuntimeMetadataV15 {
 	///
 	/// # Note
 	///
-	/// This type cannot be used directly to decode `sp_runtime::DispatchError` from the
-	/// chain. It provides just the information needed to decode `sp_runtime::DispatchError::Module`.
+	/// - This type cannot be used directly to decode `sp_runtime::DispatchError` from the
+	///   chain. It provides just the information needed to decode `sp_runtime::DispatchError::Module`.
+	/// - Decoding the 5 error bytes into this type will not always lead to all of the bytes being consumed;
+	///   many error types do not require all of the bytes to represent them fully.
 	pub module_error_enum_ty: <PortableForm as Form>::Type,
 }
 

--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -76,7 +76,7 @@ impl RuntimeMetadataV15 {
 		apis: Vec<RuntimeApiMetadata>,
 		call_enum_ty: MetaType,
 		event_enum_ty: MetaType,
-		error_enum_ty: MetaType,
+		module_error_enum_ty: MetaType,
 	) -> Self {
 		let mut registry = Registry::new();
 		let pallets = registry.map_into_portable(pallets);
@@ -85,7 +85,7 @@ impl RuntimeMetadataV15 {
 		let apis = registry.map_into_portable(apis);
 		let call_enum_ty = registry.register_type(&call_enum_ty);
 		let event_enum_ty = registry.register_type(&event_enum_ty);
-		let error_enum_ty = registry.register_type(&error_enum_ty);
+		let module_error_enum_ty = registry.register_type(&module_error_enum_ty);
 		Self {
 			types: registry.into(),
 			pallets,
@@ -94,7 +94,7 @@ impl RuntimeMetadataV15 {
 			apis,
 			call_enum_ty,
 			event_enum_ty,
-			error_enum_ty,
+			module_error_enum_ty,
 		}
 	}
 }


### PR DESCRIPTION
This PR renames the `error_enum_ty` to better reflect the type details.

Considering that it does not represent the `DispatchError` emitted by the chain,
it contains only the information needed to decode the `ModuleError` of the
`DispatchError::Module` variant.

The [ModuleError](https://docs.rs/sp-runtime/24.0.0/sp_runtime/struct.ModuleError.html) is represented by a raw form in sp-runtime:

```rust
pub struct ModuleError {
    pub index: [u8](https://doc.rust-lang.org/nightly/std/primitive.u8.html),
    pub error: [[u8](https://doc.rust-lang.org/nightly/std/primitive.u8.html); [4](https://doc.rust-lang.org/nightly/std/primitive.array.html)],
    pub message: [Option](https://doc.rust-lang.org/nightly/core/option/enum.Option.html)<&'static [str](https://doc.rust-lang.org/nightly/std/primitive.str.html)>,
}
```

This added type in the metadata will provide support for better decoding of the module error:

```rust
enum ModuleErrorType {
   System(pallet_system::Error),
   ...
}
```

Needed by: https://github.com/paritytech/substrate/pull/14143


// @paritytech/subxt-team 