### PR TITLE
v15: Remove the module_error_ty

### DIFF
--- a/frame-metadata/src/v15.rs
+++ b/frame-metadata/src/v15.rs
@@ -603,22 +603,6 @@ pub struct OuterEnums<T: Form = MetaForm> {
 	pub call_enum_ty: T::Type,
 	/// The type of the outer `RuntimeEvent` enum.
 	pub event_enum_ty: T::Type,
-	/// The module error type of the
-	/// [`DispatchError::Module`](https://docs.rs/sp-runtime/24.0.0/sp_runtime/enum.DispatchError.html#variant.Module) variant.
-	///
-	/// The `Module` variant will be 5 scale encoded bytes which are normally decoded into
-	/// an `{ index: u8, error: [u8; 4] }` struct. This type ID points to an enum type which instead
-	/// interprets the first `index` byte as a pallet variant, and the remaining `error` bytes as the
-	/// appropriate `pallet::Error` type. It is an equally valid way to decode the error bytes, and
-	/// can be more informative.
-	///
-	/// # Note
-	///
-	/// - This type cannot be used directly to decode `sp_runtime::DispatchError` from the
-	///   chain. It provides just the information needed to decode `sp_runtime::DispatchError::Module`.
-	/// - Decoding the 5 error bytes into this type will not always lead to all of the bytes being consumed;
-	///   many error types do not require all of the bytes to represent them fully.
-	pub module_error_enum_ty: T::Type,
 }
 
 impl IntoPortable for OuterEnums {
@@ -628,7 +612,6 @@ impl IntoPortable for OuterEnums {
 		OuterEnums {
 			call_enum_ty: registry.register_type(&self.call_enum_ty),
 			event_enum_ty: registry.register_type(&self.event_enum_ty),
-			module_error_enum_ty: registry.register_type(&self.module_error_enum_ty),
 		}
 	}
 }


### PR DESCRIPTION
This PR removes the module error type.

The module error type could be generated by the `construct_runtime!` macro in substrate.
The `[pallet::error]` is included as part of the pallet's definition, however the `Error` information is not part of the explicit declaration via `System: frame_system::{Event<T> ..}`, nor the implicit declaration via expansion of pallet parts as in `System: system`.
This would require us to change the way we propagate the error, because declaring errors is optional.

Remove the module error for now to stabilize the V15 metadata, leaving room for us to add it in V16 and onwards.

// @paritytech/subxt-team 