### PR TITLE
Release v15.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.2.0] - 2023-06-27
+
+### Added
+
+- V15: Add custom values to the metadata  ([#61](https://github.com/paritytech/subxt/pull/61))
+- v15/metadata: Add outer enum types for calls, events, errors  ([#57](https://github.com/paritytech/subxt/pull/57))
+- Metadata V15: Enrich extrinsic type info for decoding  ([#56](https://github.com/paritytech/subxt/pull/56))
+
+### Changed
+
+- Simplify feature-flag and use common types  ([#62](https://github.com/paritytech/subxt/pull/62))
+- v15: Rename `error_enum_ty` to `module_error_enum_ty`  ([#60](https://github.com/paritytech/subxt/pull/60))
+
 ## [15.1.0] - 2023-03-30
 
 ### Added

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "15.1.0"
+version = "15.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
### Added

- V15: Add custom values to the metadata  ([#61](https://github.com/paritytech/subxt/pull/61))
- v15/metadata: Add outer enum types for calls, events, errors  ([#57](https://github.com/paritytech/subxt/pull/57))
- Metadata V15: Enrich extrinsic type info for decoding  ([#56](https://github.com/paritytech/subxt/pull/56))

### Changed

- Simplify feature-flag and use common types  ([#62](https://github.com/paritytech/subxt/pull/62))
- v15: Rename `error_enum_ty` to `module_error_enum_ty`  ([#60](https://github.com/paritytech/subxt/pull/60))

@paritytech/subxt-team 