### PR TITLE
chore: Release v17 with v16 unstable metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.1.0] - 2024-09-16
+
+### Added
+
+- v16: Add unstable metadata v16 [#82](https://github.com/paritytech/frame-metadata/pull/82)
+
 ## [16.0.0] - 2023-06-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.0.0] - 2024-09-16
+## [17.0.0] - 2024-10-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [16.1.0] - 2024-09-16
+## [17.0.0] - 2024-09-16
 
 ### Added
 

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "16.0.0"
+version = "16.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "16.1.0"
+version = "17.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## [17.0.0] - 2024-10-16

### Added

- v16: Add unstable metadata v16 [#82](https://github.com/paritytech/frame-metadata/pull/82)

cc @paritytech/subxt-team 