### PR TITLE
v16: ExtrinsicMetadata extensions

### DIFF
--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -217,6 +217,8 @@ impl IntoPortable for ExtrinsicMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct TransactionExtensionMetadata<T: Form = MetaForm> {
+	/// Extension version.
+	pub version: u8,
 	/// The unique transaction extension identifier, which may be different from the type name.
 	pub identifier: T::String,
 	/// The type of the transaction extension, with the data to be included in the extrinsic.
@@ -230,6 +232,7 @@ impl IntoPortable for TransactionExtensionMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		TransactionExtensionMetadata {
+			version: self.version,
 			identifier: self.identifier.into_portable(registry),
 			ty: registry.register_type(&self.ty),
 			implicit: registry.register_type(&self.implicit),

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -185,14 +185,15 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
-	/// Extrinsic versions.
-	///
-	/// For each supported version number, list the indexes, in order, of the extensions used.
-	pub versions: BTreeMap<u8, Vec<u32>>,
 	/// The type of the address that signs the extrinsic
 	pub address_ty: T::Type,
 	/// The type of the extrinsic's signature.
 	pub signature_ty: T::Type,
+	/// A mapping of supported extrinsic versions to their respective transaction extension indexes.
+	/// Transaction extensions by supported versions.
+	///
+	/// For each supported version number, list the indexes, in order, of the extensions used.
+	pub transaction_extensions_by_version: BTreeMap<u8, Vec<u32>>,
 	/// The transaction extensions in the order they appear in the extrinsic.
 	pub transaction_extensions: Vec<TransactionExtensionMetadata<T>>,
 }

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -185,6 +185,8 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
+	/// Extrinsic versions.
+	pub versions: Vec<u8>,
 	/// The type of the address that signs the extrinsic
 	pub address_ty: T::Type,
 	/// The type of the extrinsic's signature.
@@ -203,6 +205,7 @@ impl IntoPortable for ExtrinsicMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
+			versions: self.versions,
 			address_ty: registry.register_type(&self.address_ty),
 			signature_ty: registry.register_type(&self.signature_ty),
 			transaction_extensions_by_version: self.transaction_extensions_by_version,

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -191,8 +191,7 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	pub address_ty: T::Type,
 	/// The type of the extrinsic's signature.
 	pub signature_ty: T::Type,
-	/// A mapping of supported extrinsic versions to their respective transaction extension indexes.
-	/// Transaction extensions by supported versions.
+	/// A mapping of supported transaction extrinsic versions to their respective transaction extension indexes.
 	///
 	/// For each supported version number, list the indexes, in order, of the extensions used.
 	pub transaction_extensions_by_version: BTreeMap<u8, Vec<u32>>,

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -185,7 +185,7 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
-	/// Extrinsic versions.
+	/// Extrinsic versions supported by the runtime.
 	pub versions: Vec<u8>,
 	/// The type of the address that signs the extrinsic
 	pub address_ty: T::Type,

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -203,9 +203,9 @@ impl IntoPortable for ExtrinsicMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		ExtrinsicMetadata {
-			versions: self.versions,
 			address_ty: registry.register_type(&self.address_ty),
 			signature_ty: registry.register_type(&self.signature_ty),
+			transaction_extensions_by_version: self.transaction_extensions_by_version,
 			transaction_extensions: registry.map_into_portable(self.transaction_extensions),
 		}
 	}

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -187,7 +187,7 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// Extrinsic versions.
 	pub versions: Vec<u8>,
-	/// The type of the address that signes the extrinsic
+	/// The type of the address that signs the extrinsic
 	pub address_ty: T::Type,
 	/// The type of the extrinsic's signature.
 	pub signature_ty: T::Type,

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -221,8 +221,8 @@ pub struct TransactionExtensionMetadata<T: Form = MetaForm> {
 	pub identifier: T::String,
 	/// The type of the transaction extension, with the data to be included in the extrinsic.
 	pub ty: T::Type,
-	/// The type of the additional transaction data, with the data to be included in the signed payload.
-	pub additional_signed: T::Type,
+	/// The type of the implicit data, with the data to be included in the signed payload.
+	pub implicit: T::Type,
 }
 
 impl IntoPortable for TransactionExtensionMetadata {
@@ -232,7 +232,7 @@ impl IntoPortable for TransactionExtensionMetadata {
 		TransactionExtensionMetadata {
 			identifier: self.identifier.into_portable(registry),
 			ty: registry.register_type(&self.ty),
-			additional_signed: registry.register_type(&self.additional_signed),
+			implicit: registry.register_type(&self.implicit),
 		}
 	}
 }

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -186,7 +186,9 @@ impl IntoPortable for RuntimeApiMethodParamMetadata {
 )]
 pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// Extrinsic versions.
-	pub versions: Vec<u8>,
+	///
+	/// For each supported version number, list the indexes, in order, of the extensions used.
+	pub versions: BTreeMap<u8, Vec<u32>>,
 	/// The type of the address that signs the extrinsic
 	pub address_ty: T::Type,
 	/// The type of the extrinsic's signature.
@@ -217,8 +219,6 @@ impl IntoPortable for ExtrinsicMetadata {
 	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
 )]
 pub struct TransactionExtensionMetadata<T: Form = MetaForm> {
-	/// Extension version.
-	pub version: u8,
 	/// The unique transaction extension identifier, which may be different from the type name.
 	pub identifier: T::String,
 	/// The type of the transaction extension, with the data to be included in the extrinsic.
@@ -232,7 +232,6 @@ impl IntoPortable for TransactionExtensionMetadata {
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		TransactionExtensionMetadata {
-			version: self.version,
 			identifier: self.identifier.into_portable(registry),
 			ty: registry.register_type(&self.ty),
 			implicit: registry.register_type(&self.implicit),

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -193,8 +193,6 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	pub call_ty: T::Type,
 	/// The type of the extrinsic's signature.
 	pub signature_ty: T::Type,
-	/// The type of the outermost Extra enum.
-	pub extra_ty: T::Type,
 	/// The transaction extensions in the order they appear in the extrinsic.
 	pub transaction_extensions: Vec<TransactionExtensionMetadata<T>>,
 }
@@ -208,7 +206,6 @@ impl IntoPortable for ExtrinsicMetadata {
 			address_ty: registry.register_type(&self.address_ty),
 			call_ty: registry.register_type(&self.call_ty),
 			signature_ty: registry.register_type(&self.signature_ty),
-			extra_ty: registry.register_type(&self.extra_ty),
 			transaction_extensions: registry.map_into_portable(self.transaction_extensions),
 		}
 	}

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -189,8 +189,6 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	pub versions: Vec<u8>,
 	/// The type of the address that signes the extrinsic
 	pub address_ty: T::Type,
-	/// The type of the outermost Call enum.
-	pub call_ty: T::Type,
 	/// The type of the extrinsic's signature.
 	pub signature_ty: T::Type,
 	/// The transaction extensions in the order they appear in the extrinsic.
@@ -204,7 +202,6 @@ impl IntoPortable for ExtrinsicMetadata {
 		ExtrinsicMetadata {
 			versions: self.versions,
 			address_ty: registry.register_type(&self.address_ty),
-			call_ty: registry.register_type(&self.call_ty),
 			signature_ty: registry.register_type(&self.signature_ty),
 			transaction_extensions: registry.map_into_portable(self.transaction_extensions),
 		}


### PR DESCRIPTION
This PR adds the following to the v16 metadata:
- remove `ExtrinsicMetadata::call_ty` as it can be found in the other enums field of the metadata
- remove `ExtrinsicMetadata::extra_ty` as it can be found in the tx extensions
- rename `TransactionExtensionMetadata::additional_signed` to `TransactionExtensionMetadata::implicit`
- add `TransactionExtensionMetadata::version` u8 for versioning extensions 


cc @paritytech/subxt-team 