### PR TITLE
chore: Release v18.0.0 with unstable v16 `ExtrinsicMetadata` extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.1.0] - 2024-11-13
+
+### Changed
+
+- v16: ExtrinsicMetadata extensions [#86](https://github.com/paritytech/frame-metadata/pull/86)
+
 ## [17.0.0] - 2024-10-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [17.1.0] - 2024-11-13
+## [18.0.0] - 2024-11-13
 
 ### Changed
 

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "17.0.0"
+version = "17.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "17.1.0"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## [18.0.0] - 2024-11-13

### Changed

- v16: ExtrinsicMetadata extensions [#86](https://github.com/paritytech/frame-metadata/pull/86)


cc @paritytech/subxt-team 