### PR TITLE
Allow `Zlib` and `Unicode-3.0` licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,8 @@ allow = [
     "MIT",
     "Apache-2.0",
     "Unicode-DFS-2016",
+    "Zlib",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
Allowing two new open source licenses:

- `Zlib`: has been approved by the FSF as a free software license and by the OSI as an open source license.
- `Unicode-3.0`: has been approved by the OSI as an open source license.

This will fix a [failing CI](https://github.com/paritytech/frame-metadata/actions/runs/13072803858/job/36855679806?pr=89).