### PR TITLE
Add Runtime Api version to v16

### DIFF
--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -193,7 +193,7 @@ impl RuntimeMetadata {
 			RuntimeMetadata::V13(_) => 13,
 			RuntimeMetadata::V14(_) => 14,
 			RuntimeMetadata::V15(_) => 15,
-			RuntimeMetadata::V16(_) => 16,
+			RuntimeMetadata::V16(_) => u32::MAX,
 		}
 	}
 }

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -193,7 +193,7 @@ impl RuntimeMetadata {
 			RuntimeMetadata::V13(_) => 13,
 			RuntimeMetadata::V14(_) => 14,
 			RuntimeMetadata::V15(_) => 15,
-			RuntimeMetadata::V16(_) => u32::MAX,
+			RuntimeMetadata::V16(_) => 16,
 		}
 	}
 }

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -19,7 +19,7 @@ use codec::Decode;
 use serde::Serialize;
 
 use super::{RuntimeMetadataPrefixed, META_RESERVED};
-use codec::Encode;
+use codec::{Compact, Encode};
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
@@ -98,8 +98,10 @@ pub struct RuntimeApiMetadata<T: Form = MetaForm> {
 	pub methods: Vec<RuntimeApiMethodMetadata<T>>,
 	/// Trait documentation.
 	pub docs: Vec<T::String>,
-	/// Deprecation info
+	/// Deprecation info.
 	pub deprecation_info: DeprecationStatus<T>,
+	/// Runtime API version.
+	pub version: Compact<u32>,
 }
 
 impl IntoPortable for RuntimeApiMetadata {
@@ -111,6 +113,7 @@ impl IntoPortable for RuntimeApiMetadata {
 			methods: registry.map_into_portable(self.methods),
 			docs: registry.map_into_portable(self.docs),
 			deprecation_info: self.deprecation_info.into_portable(registry),
+			version: self.version,
 		}
 	}
 }

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -19,7 +19,7 @@ use codec::Decode;
 use serde::Serialize;
 
 use super::{RuntimeMetadataPrefixed, META_RESERVED};
-use codec::{Compact, Encode};
+use codec::Encode;
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
@@ -101,7 +101,7 @@ pub struct RuntimeApiMetadata<T: Form = MetaForm> {
 	/// Deprecation info.
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Runtime API version.
-	pub version: Compact<u32>,
+	pub version: u32,
 }
 
 impl IntoPortable for RuntimeApiMetadata {


### PR DESCRIPTION
This solves https://github.com/paritytech/polkadot-sdk/issues/7352 on the `frame-metadata` side and it will be completed by https://github.com/paritytech/polkadot-sdk/pull/7607 on the runtime side.