### PR TITLE
chore: Release frame-metadata v20.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [20.0.0] - 2025-02-20
+
+Metadata version 16 is currently unstable and can be enabled using the unstable feature flag.
+
+### Added
+
+- Add Runtime Api version to v16 [#92](https://github.com/paritytech/frame-metadata/pull/92)
+
 ## [19.0.0] - 2025-02-11
 
 Metadata version 16 is currently unstable and can be enabled using the unstable feature flag.

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "19.0.0"
+version = "20.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## [20.0.0] - 2025-02-20

Metadata version 16 is currently unstable and can be enabled using the unstable feature flag.

### Added

- Add Runtime Api version to v16 [#92](https://github.com/paritytech/frame-metadata/pull/92)

cc @paritytech/subxt-team @re-gius 