### PR TITLE
Address V16 pre-stabilization niggles

### DIFF
--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -33,6 +33,7 @@ unstable = ["current"]
 # Serde support without relying on std features
 serde_full = [
 	"scale-info/serde",
+	"codec/serde",
 	"serde",
 	"serde/alloc",
 ]

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -19,7 +19,7 @@ use codec::Decode;
 use serde::Serialize;
 
 use super::{RuntimeMetadataPrefixed, META_RESERVED};
-use codec::{Compact, Encode};
+use codec::Encode;
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
@@ -592,5 +592,35 @@ impl IntoPortable for DeprecationInfo {
 			}
 			Self::NotDeprecated => DeprecationInfo::NotDeprecated,
 		}
+	}
+}
+
+/// A wrapper around [`codec::Compact`] which is compact
+/// encoded and can be transparently serialized via serde.
+// Dev note: If we add Serializing to codec::Compact, this
+// can be removed without altering the SCALE encoding.
+#[derive(Clone, Copy, PartialEq, Eq, Encode, Debug)]
+#[cfg_attr(feature = "decode", derive(Decode))]
+#[cfg_attr(feature = "serde_full", derive(Serialize))]
+#[cfg_attr(feature = "serde_full", serde(from = "T"))]
+pub struct Compact<T>(codec::Compact<T>);
+
+impl<T> core::ops::Deref for Compact<T> {
+	type Target = T;
+	fn deref(&self) -> &Self::Target {
+		&self.0 .0
+	}
+}
+
+impl<T> From<T> for Compact<T> {
+	fn from(x: T) -> Compact<T> {
+		Compact(codec::Compact(x))
+	}
+}
+
+impl<T> Compact<T> {
+	/// Retrieve the inner value.
+	pub fn inner(self) -> T {
+		self.0 .0
 	}
 }

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -107,7 +107,7 @@ pub struct RuntimeApiMetadata<T: Form = MetaForm> {
 	/// Deprecation info.
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Runtime API version.
-	pub version: Compact<u32>,
+	pub version: CompactSer<u32>,
 }
 
 impl IntoPortable for RuntimeApiMetadata {
@@ -177,7 +177,7 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// A mapping of supported transaction extrinsic versions to their respective transaction extension indexes.
 	///
 	/// For each supported version number, list the indexes, in order, of the extensions used.
-	pub transaction_extensions_by_version: BTreeMap<u8, Vec<Compact<u32>>>,
+	pub transaction_extensions_by_version: BTreeMap<u8, Vec<CompactSer<u32>>>,
 	/// The transaction extensions in the order they appear in the extrinsic.
 	pub transaction_extensions: Vec<TransactionExtensionMetadata<T>>,
 }
@@ -603,22 +603,22 @@ impl IntoPortable for DeprecationInfo {
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
 #[cfg_attr(feature = "serde_full", serde(from = "T"))]
-pub struct Compact<T>(codec::Compact<T>);
+pub struct CompactSer<T>(codec::Compact<T>);
 
-impl<T> core::ops::Deref for Compact<T> {
+impl<T> core::ops::Deref for CompactSer<T> {
 	type Target = T;
 	fn deref(&self) -> &Self::Target {
 		&self.0 .0
 	}
 }
 
-impl<T> From<T> for Compact<T> {
-	fn from(x: T) -> Compact<T> {
-		Compact(codec::Compact(x))
+impl<T> From<T> for CompactSer<T> {
+	fn from(x: T) -> CompactSer<T> {
+		CompactSer(codec::Compact(x))
 	}
 }
 
-impl<T> Compact<T> {
+impl<T> CompactSer<T> {
 	/// Retrieve the inner value.
 	pub fn inner(self) -> T {
 		self.0 .0

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -19,7 +19,7 @@ use codec::Decode;
 use serde::Serialize;
 
 use super::{RuntimeMetadataPrefixed, META_RESERVED};
-use codec::Encode;
+use codec::{Compact, Encode};
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
@@ -107,7 +107,7 @@ pub struct RuntimeApiMetadata<T: Form = MetaForm> {
 	/// Deprecation info.
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Runtime API version.
-	pub version: CompactSer<u32>,
+	pub version: Compact<u32>,
 }
 
 impl IntoPortable for RuntimeApiMetadata {
@@ -177,7 +177,7 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// A mapping of supported transaction extrinsic versions to their respective transaction extension indexes.
 	///
 	/// For each supported version number, list the indexes, in order, of the extensions used.
-	pub transaction_extensions_by_version: BTreeMap<u8, Vec<CompactSer<u32>>>,
+	pub transaction_extensions_by_version: BTreeMap<u8, Vec<Compact<u32>>>,
 	/// The transaction extensions in the order they appear in the extrinsic.
 	pub transaction_extensions: Vec<TransactionExtensionMetadata<T>>,
 }
@@ -592,35 +592,5 @@ impl IntoPortable for DeprecationInfo {
 			}
 			Self::NotDeprecated => DeprecationInfo::NotDeprecated,
 		}
-	}
-}
-
-/// A wrapper around [`codec::Compact`] which is compact
-/// encoded and can be transparently serialized via serde.
-// Dev note: If we add Serializing to codec::Compact, this
-// can be removed without altering the SCALE encoding.
-#[derive(Clone, Copy, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(feature = "serde_full", serde(from = "T"))]
-pub struct CompactSer<T>(codec::Compact<T>);
-
-impl<T> core::ops::Deref for CompactSer<T> {
-	type Target = T;
-	fn deref(&self) -> &Self::Target {
-		&self.0 .0
-	}
-}
-
-impl<T> From<T> for CompactSer<T> {
-	fn from(x: T) -> CompactSer<T> {
-		CompactSer(codec::Compact(x))
-	}
-}
-
-impl<T> CompactSer<T> {
-	/// Retrieve the inner value.
-	pub fn inner(self) -> T {
-		self.0 .0
 	}
 }

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -27,12 +27,8 @@ use scale_info::{
 };
 
 // These types have not changed, so we re-export from our v14/v15 definitions:
-pub use super::v14::{
-	StorageEntryModifier, StorageEntryType, StorageHasher,
-};
-pub use super::v15::{
-	CustomMetadata, CustomValueMetadata, OuterEnums,
-};
+pub use super::v14::{StorageEntryModifier, StorageEntryType, StorageHasher};
+pub use super::v15::{CustomMetadata, CustomValueMetadata, OuterEnums};
 
 /// The metadata for a method or function parameter. This is identical to
 /// [`crate::v15::RuntimeApiMethodParamMetadata`].

--- a/frame-metadata/src/v16.rs
+++ b/frame-metadata/src/v16.rs
@@ -19,16 +19,26 @@ use codec::Decode;
 use serde::Serialize;
 
 use super::{RuntimeMetadataPrefixed, META_RESERVED};
-use codec::Encode;
+use codec::{Compact, Encode};
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
 	IntoPortable, PortableRegistry, Registry,
 };
 
-pub use super::v14::{StorageEntryModifier, StorageEntryType, StorageHasher};
+// These types have not changed, so we re-export from our v14/v15 definitions:
+pub use super::v14::{
+	StorageEntryModifier, StorageEntryType, StorageHasher,
+};
+pub use super::v15::{
+	CustomMetadata, CustomValueMetadata, OuterEnums,
+};
 
-/// Latest runtime metadata
+/// The metadata for a method or function parameter. This is identical to
+/// [`crate::v15::RuntimeApiMethodParamMetadata`].
+pub type FunctionParamMetadata<T> = super::v15::RuntimeApiMethodParamMetadata<T>;
+
+/// Latest runtime metadata.
 pub type RuntimeMetadataLastVersion = RuntimeMetadataV16;
 
 impl From<RuntimeMetadataLastVersion> for super::RuntimeMetadataPrefixed {
@@ -101,7 +111,7 @@ pub struct RuntimeApiMetadata<T: Form = MetaForm> {
 	/// Deprecation info.
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Runtime API version.
-	pub version: u32,
+	pub version: Compact<u32>,
 }
 
 impl IntoPortable for RuntimeApiMetadata {
@@ -130,7 +140,7 @@ pub struct RuntimeApiMethodMetadata<T: Form = MetaForm> {
 	/// Method name.
 	pub name: T::String,
 	/// Method parameters.
-	pub inputs: Vec<RuntimeApiMethodParamMetadata<T>>,
+	pub inputs: Vec<FunctionParamMetadata<T>>,
 	/// Method output.
 	pub output: T::Type,
 	/// Method documentation.
@@ -153,32 +163,6 @@ impl IntoPortable for RuntimeApiMethodMetadata {
 	}
 }
 
-/// Metadata of a runtime method parameter.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(
-	feature = "serde_full",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
-pub struct RuntimeApiMethodParamMetadata<T: Form = MetaForm> {
-	/// Parameter name.
-	pub name: T::String,
-	/// Parameter type.
-	pub ty: T::Type,
-}
-
-impl IntoPortable for RuntimeApiMethodParamMetadata {
-	type Output = RuntimeApiMethodParamMetadata<PortableForm>;
-
-	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		RuntimeApiMethodParamMetadata {
-			name: self.name.into_portable(registry),
-			ty: registry.register_type(&self.ty),
-		}
-	}
-}
-
 /// Metadata of the extrinsic used by the runtime.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
@@ -197,7 +181,7 @@ pub struct ExtrinsicMetadata<T: Form = MetaForm> {
 	/// A mapping of supported transaction extrinsic versions to their respective transaction extension indexes.
 	///
 	/// For each supported version number, list the indexes, in order, of the extensions used.
-	pub transaction_extensions_by_version: BTreeMap<u8, Vec<u32>>,
+	pub transaction_extensions_by_version: BTreeMap<u8, Vec<Compact<u32>>>,
 	/// The transaction extensions in the order they appear in the extrinsic.
 	pub transaction_extensions: Vec<TransactionExtensionMetadata<T>>,
 }
@@ -299,7 +283,7 @@ impl IntoPortable for PalletMetadata {
 	}
 }
 
-/// Metadata for all calls in a pallet
+/// Metadata for all calls in a pallet.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 #[cfg_attr(feature = "decode", derive(Decode))]
 #[cfg_attr(feature = "serde_full", derive(Serialize))]
@@ -519,7 +503,7 @@ pub struct PalletViewFunctionMetadata<T: Form = MetaForm> {
 	/// Method id.
 	pub id: [u8; 32],
 	/// Method parameters.
-	pub inputs: Vec<PalletViewFunctionParamMetadata<T>>,
+	pub inputs: Vec<FunctionParamMetadata<T>>,
 	/// Method output.
 	pub output: T::Type,
 	/// Method documentation.
@@ -539,130 +523,6 @@ impl IntoPortable for PalletViewFunctionMetadata {
 			output: registry.register_type(&self.output),
 			docs: registry.map_into_portable(self.docs),
 			deprecation_info: self.deprecation_info.into_portable(registry),
-		}
-	}
-}
-
-/// Metadata of a runtime view function parameter.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(
-	feature = "serde_full",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
-pub struct PalletViewFunctionParamMetadata<T: Form = MetaForm> {
-	/// Parameter name.
-	pub name: T::String,
-	/// Parameter type.
-	pub ty: T::Type,
-}
-
-impl IntoPortable for PalletViewFunctionParamMetadata {
-	type Output = PalletViewFunctionParamMetadata<PortableForm>;
-
-	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		PalletViewFunctionParamMetadata {
-			name: self.name.into_portable(registry),
-			ty: registry.register_type(&self.ty),
-		}
-	}
-}
-
-/// Metadata for custom types.
-///
-/// This map associates a string key to a `CustomValueMetadata`.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(
-	feature = "serde_full",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
-pub struct CustomMetadata<T: Form = MetaForm> {
-	/// The custom map.
-	pub map: BTreeMap<T::String, CustomValueMetadata<T>>,
-}
-
-impl IntoPortable for CustomMetadata {
-	type Output = CustomMetadata<PortableForm>;
-
-	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		let map = self
-			.map
-			.into_iter()
-			.map(|(key, value)| (key.into_portable(registry), value.into_portable(registry)))
-			.collect();
-
-		CustomMetadata { map }
-	}
-}
-
-/// The associated value of a custom metadata type.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(
-	feature = "serde_full",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
-pub struct CustomValueMetadata<T: Form = MetaForm> {
-	/// The custom type.
-	pub ty: T::Type,
-	/// The custom value of this type.
-	pub value: Vec<u8>,
-}
-
-impl IntoPortable for CustomValueMetadata {
-	type Output = CustomValueMetadata<PortableForm>;
-
-	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		CustomValueMetadata {
-			ty: registry.register_type(&self.ty),
-			value: self.value,
-		}
-	}
-}
-
-/// The type of the outer enums.
-#[derive(Clone, PartialEq, Eq, Encode, Debug)]
-#[cfg_attr(feature = "decode", derive(Decode))]
-#[cfg_attr(feature = "serde_full", derive(Serialize))]
-#[cfg_attr(
-	feature = "serde_full",
-	serde(bound(serialize = "T::Type: Serialize, T::String: Serialize"))
-)]
-pub struct OuterEnums<T: Form = MetaForm> {
-	/// The type of the outer `RuntimeCall` enum.
-	pub call_enum_ty: T::Type,
-	/// The type of the outer `RuntimeEvent` enum.
-	pub event_enum_ty: T::Type,
-	/// The module error type of the
-	/// [`DispatchError::Module`](https://docs.rs/sp-runtime/24.0.0/sp_runtime/enum.DispatchError.html#variant.Module) variant.
-	///
-	/// The `Module` variant will be 5 scale encoded bytes which are normally decoded into
-	/// an `{ index: u8, error: [u8; 4] }` struct. This type ID points to an enum type which instead
-	/// interprets the first `index` byte as a pallet variant, and the remaining `error` bytes as the
-	/// appropriate `pallet::Error` type. It is an equally valid way to decode the error bytes, and
-	/// can be more informative.
-	///
-	/// # Note
-	///
-	/// - This type cannot be used directly to decode `sp_runtime::DispatchError` from the
-	///   chain. It provides just the information needed to decode `sp_runtime::DispatchError::Module`.
-	/// - Decoding the 5 error bytes into this type will not always lead to all of the bytes being consumed;
-	///   many error types do not require all of the bytes to represent them fully.
-	pub error_enum_ty: T::Type,
-}
-
-impl IntoPortable for OuterEnums {
-	type Output = OuterEnums<PortableForm>;
-
-	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		OuterEnums {
-			call_enum_ty: registry.register_type(&self.call_enum_ty),
-			event_enum_ty: registry.register_type(&self.event_enum_ty),
-			error_enum_ty: registry.register_type(&self.error_enum_ty),
 		}
 	}
 }


### PR DESCRIPTION
Address some niggles in the V16 format; a couple of `Compact`s to reduce the size a little, and sharing more types for easier from/into conversions in other crates.

Closes #94 
Closes #95 
Closes #96