### PR TITLE
Prepare to release 21.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [21.0.0] - 2025-04-01
+
+### Changed
+
+- Address some small niggles in the unstable V16 metadata [#98](https://github.com/paritytech/frame-metadata/pull/98)
+
 ## [20.0.0] - 2025-02-20
 
 Metadata version 16 is currently unstable and can be enabled using the unstable feature flag.

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "20.0.0"
+version = "21.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## [21.0.0] - 2025-04-01

### Changed

- Address some small niggles in the unstable V16 metadata [#98](https://github.com/paritytech/frame-metadata/pull/98)