### PR TITLE
Prepare to stabilize V16 metadata and release v23.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [23.0.0] - 2025-05-06
+
+This version stabilizes metadata V16, moving it from being marked as "unstable" and hidden behind that feature flag, to being "current" and having version 16 rather than `u32::MAX`.
+
 ## [22.0.0] - 2025-04-24
 
 ### Changed

--- a/frame-metadata/Cargo.toml
+++ b/frame-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "22.0.0"
+version = "23.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/frame-metadata/src/lib.rs
+++ b/frame-metadata/src/lib.rs
@@ -75,8 +75,8 @@ pub mod v14;
 #[cfg(feature = "current")]
 pub mod v15;
 
-/// Unstable Metadata v16
-#[cfg(feature = "unstable")]
+/// Metadata v16
+#[cfg(feature = "current")]
 pub mod v16;
 
 /// Metadata prefix.
@@ -166,10 +166,10 @@ pub enum RuntimeMetadata {
 	#[cfg(not(feature = "current"))]
 	V15(OpaqueMetadata),
 	/// Version 16 for runtime metadata.
-	#[cfg(feature = "unstable")]
+	#[cfg(feature = "current")]
 	V16(v16::RuntimeMetadataV16),
 	/// Version 16 for runtime metadata, as raw encoded bytes.
-	#[cfg(not(feature = "unstable"))]
+	#[cfg(not(feature = "current"))]
 	V16(OpaqueMetadata),
 }
 
@@ -193,7 +193,7 @@ impl RuntimeMetadata {
 			RuntimeMetadata::V13(_) => 13,
 			RuntimeMetadata::V14(_) => 14,
 			RuntimeMetadata::V15(_) => 15,
-			RuntimeMetadata::V16(_) => u32::MAX,
+			RuntimeMetadata::V16(_) => 16,
 		}
 	}
 }


### PR DESCRIPTION
This release stabilizes metadata V16, moving it from being marked as "unstable" and hidden behind that feature flag, to being "current" and having version 16 rather than `u32::MAX`.
